### PR TITLE
Change spaces to underscores in filenames, add README comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Note that the `-common-name` flag is required, and will be used to name output f
 Moreover, this will also generate a new keypair for the Certificate Authority,
 though you can use a pre-existing private PEM key with the `-key` flag.
 
+If the CN contains spaces, certstrap will change them to underscores in the filename for easier use.  The spaces will be preserved inside the fields of the generated files:
+
+```
+$ ./certstrap init --common-name "Cert Auth"
+Created out/Cert_Auth.key
+Created out/Cert_Auth.crt
+```
+
 ### Request a certificate, including keypair:
 
 ```

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/square/certstrap/Godeps/_workspace/src/github.com/codegangsta/cli"
 	"github.com/square/certstrap/depot"
@@ -57,9 +58,9 @@ func initAction(c *cli.Context) {
 		os.Exit(1)
 	}
 
-	name := c.String("common-name")
+	formattedName := strings.Replace(c.String("common-name"), " ", "_", -1)
 
-	if depot.CheckCertificate(d, name) || depot.CheckPrivateKey(d, name) {
+	if depot.CheckCertificate(d, formattedName) || depot.CheckPrivateKey(d, formattedName) {
 		fmt.Fprintln(os.Stderr, "CA with specified name already exists!")
 		os.Exit(1)
 	}
@@ -84,7 +85,7 @@ func initAction(c *cli.Context) {
 			fmt.Fprintln(os.Stderr, "Read Key error:", err)
 			os.Exit(1)
 		}
-		fmt.Printf("Read %s.key\n", name)
+		fmt.Printf("Read %s\n", c.String("key"))
 	} else {
 		key, err = pkix.CreateRSAKey(c.Int("key-bits"))
 		if err != nil {
@@ -92,9 +93,9 @@ func initAction(c *cli.Context) {
 			os.Exit(1)
 		}
 		if len(passphrase) > 0 {
-			fmt.Printf("Created %s/%s.key (encrypted by passphrase)\n", depotDir, name)
+			fmt.Printf("Created %s/%s.key (encrypted by passphrase)\n", depotDir, formattedName)
 		} else {
-			fmt.Printf("Created %s/%s.key\n", depotDir, name)
+			fmt.Printf("Created %s/%s.key\n", depotDir, formattedName)
 		}
 	}
 
@@ -103,7 +104,7 @@ func initAction(c *cli.Context) {
 		fmt.Fprintln(os.Stderr, "Create certificate error:", err)
 		os.Exit(1)
 	} else {
-		fmt.Printf("Created %s/%s.crt\n", depotDir, name)
+		fmt.Printf("Created %s/%s.crt\n", depotDir, formattedName)
 	}
 
 	if c.Bool("stdout") {
@@ -116,15 +117,15 @@ func initAction(c *cli.Context) {
 		}
 	}
 
-	if err = depot.PutCertificate(d, name, crt); err != nil {
+	if err = depot.PutCertificate(d, formattedName, crt); err != nil {
 		fmt.Fprintln(os.Stderr, "Save certificate error:", err)
 	}
 	if len(passphrase) > 0 {
-		if err = depot.PutEncryptedPrivateKey(d, name, key, passphrase); err != nil {
+		if err = depot.PutEncryptedPrivateKey(d, formattedName, key, passphrase); err != nil {
 			fmt.Fprintln(os.Stderr, "Save encrypted private key error:", err)
 		}
 	} else {
-		if err = depot.PutPrivateKey(d, name, key); err != nil {
+		if err = depot.PutPrivateKey(d, formattedName, key); err != nil {
 			fmt.Fprintln(os.Stderr, "Save private key error:", err)
 		}
 	}

--- a/cmd/request_cert.go
+++ b/cmd/request_cert.go
@@ -74,7 +74,9 @@ func newCertAction(c *cli.Context) {
 		os.Exit(1)
 	}
 
-	if depot.CheckCertificateSigningRequest(d, name) || depot.CheckPrivateKey(d, name) {
+	formattedName := strings.Replace(name, " ", "_", -1)
+
+	if depot.CheckCertificateSigningRequest(d, formattedName) || depot.CheckPrivateKey(d, formattedName) {
 		fmt.Fprintln(os.Stderr, "Certificate request has existed!")
 		os.Exit(1)
 	}
@@ -107,9 +109,9 @@ func newCertAction(c *cli.Context) {
 			os.Exit(1)
 		}
 		if len(passphrase) > 0 {
-			fmt.Printf("Created %s/%s.key (encrypted by passphrase)\n", depotDir, name)
+			fmt.Printf("Created %s/%s.key (encrypted by passphrase)\n", depotDir, formattedName)
 		} else {
-			fmt.Printf("Created %s/%s.key\n", depotDir, name)
+			fmt.Printf("Created %s/%s.key\n", depotDir, formattedName)
 		}
 	}
 
@@ -118,7 +120,7 @@ func newCertAction(c *cli.Context) {
 		fmt.Fprintln(os.Stderr, "Create certificate request error:", err)
 		os.Exit(1)
 	} else {
-		fmt.Printf("Created %s/%s.csr\n", depotDir, name)
+		fmt.Printf("Created %s/%s.csr\n", depotDir, formattedName)
 	}
 
 	if c.Bool("stdout") {
@@ -131,15 +133,15 @@ func newCertAction(c *cli.Context) {
 		}
 	}
 
-	if err = depot.PutCertificateSigningRequest(d, name, csr); err != nil {
+	if err = depot.PutCertificateSigningRequest(d, formattedName, csr); err != nil {
 		fmt.Fprintln(os.Stderr, "Save certificate request error:", err)
 	}
 	if len(passphrase) > 0 {
-		if err = depot.PutEncryptedPrivateKey(d, name, key, passphrase); err != nil {
+		if err = depot.PutEncryptedPrivateKey(d, formattedName, key, passphrase); err != nil {
 			fmt.Fprintln(os.Stderr, "Save encrypted private key error:", err)
 		}
 	} else {
-		if err = depot.PutPrivateKey(d, name, key); err != nil {
+		if err = depot.PutPrivateKey(d, formattedName, key); err != nil {
 			fmt.Fprintln(os.Stderr, "Save private key error:", err)
 		}
 	}

--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -48,27 +48,28 @@ func newSignAction(c *cli.Context) {
 		fmt.Fprintln(os.Stderr, "One host name must be provided.")
 		os.Exit(1)
 	}
-	formattedName := strings.Replace(c.Args()[0], " ", "_", -1)
+	formattedReqName := strings.Replace(c.Args()[0], " ", "_", -1)
+	formattedCAName := strings.Replace(c.String("CA"), " ", "_", -1)
 
-	if depot.CheckCertificate(d, formattedName) {
+	if depot.CheckCertificate(d, formattedReqName) {
 		fmt.Fprintln(os.Stderr, "Certificate has existed!")
 		os.Exit(1)
 	}
 
-	csr, err := depot.GetCertificateSigningRequest(d, formattedName)
+	csr, err := depot.GetCertificateSigningRequest(d, formattedReqName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Get certificate request error:", err)
 		os.Exit(1)
 	}
-	crt, err := depot.GetCertificate(d, c.String("CA"))
+	crt, err := depot.GetCertificate(d, formattedCAName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Get CA certificate error:", err)
 		os.Exit(1)
 	}
 
-	key, err := depot.GetPrivateKey(d, c.String("CA"))
+	key, err := depot.GetPrivateKey(d, formattedCAName)
 	if err != nil {
-		key, err = depot.GetEncryptedPrivateKey(d, c.String("CA"), getPassPhrase(c, "CA key"))
+		key, err = depot.GetEncryptedPrivateKey(d, formattedCAName, getPassPhrase(c, "CA key"))
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "Get CA key error:", err)
 			os.Exit(1)
@@ -80,7 +81,7 @@ func newSignAction(c *cli.Context) {
 		fmt.Fprintln(os.Stderr, "Create certificate error:", err)
 		os.Exit(1)
 	} else {
-		fmt.Printf("Created %s/%s.crt from %s/%s.csr signed by %s/%s.key\n", depotDir, formattedName, depotDir, formattedName, depotDir, c.String("CA"))
+		fmt.Printf("Created %s/%s.crt from %s/%s.csr signed by %s/%s.key\n", depotDir, formattedReqName, depotDir, formattedReqName, depotDir, formattedCAName)
 	}
 
 	if c.Bool("stdout") {
@@ -93,7 +94,7 @@ func newSignAction(c *cli.Context) {
 		}
 	}
 
-	if err = depot.PutCertificate(d, formattedName, crtHost); err != nil {
+	if err = depot.PutCertificate(d, formattedReqName, crtHost); err != nil {
 		fmt.Fprintln(os.Stderr, "Save certificate error:", err)
 	}
 }

--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/square/certstrap/Godeps/_workspace/src/github.com/codegangsta/cli"
 	"github.com/square/certstrap/depot"
@@ -47,14 +48,14 @@ func newSignAction(c *cli.Context) {
 		fmt.Fprintln(os.Stderr, "One host name must be provided.")
 		os.Exit(1)
 	}
-	name := c.Args()[0]
+	formattedName := strings.Replace(c.Args()[0], " ", "_", -1)
 
-	if depot.CheckCertificate(d, name) {
+	if depot.CheckCertificate(d, formattedName) {
 		fmt.Fprintln(os.Stderr, "Certificate has existed!")
 		os.Exit(1)
 	}
 
-	csr, err := depot.GetCertificateSigningRequest(d, name)
+	csr, err := depot.GetCertificateSigningRequest(d, formattedName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Get certificate request error:", err)
 		os.Exit(1)
@@ -79,7 +80,7 @@ func newSignAction(c *cli.Context) {
 		fmt.Fprintln(os.Stderr, "Create certificate error:", err)
 		os.Exit(1)
 	} else {
-		fmt.Printf("Created %s/%s.crt from %s/%s.csr signed by %s/%s.key\n", depotDir, name, depotDir, name, depotDir, c.String("CA"))
+		fmt.Printf("Created %s/%s.crt from %s/%s.csr signed by %s/%s.key\n", depotDir, formattedName, depotDir, formattedName, depotDir, c.String("CA"))
 	}
 
 	if c.Bool("stdout") {
@@ -92,7 +93,7 @@ func newSignAction(c *cli.Context) {
 		}
 	}
 
-	if err = depot.PutCertificate(d, name, crtHost); err != nil {
+	if err = depot.PutCertificate(d, formattedName, crtHost); err != nil {
 		fmt.Fprintln(os.Stderr, "Save certificate error:", err)
 	}
 }


### PR DESCRIPTION
As suggested in #5, uses strings.Replace to change spaces to underscores.

(Recreated, original closed by mistake)

R: @sul3n3t