### PR TITLE
set MaxPathLenZero to true

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 sudo: false
 
 go:
-- 1.3
 - 1.4
 - tip
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ certstrap can init multiple certificate authorities to sign certificates with.  
 
 ### Building
 
-certstrap must be built with Go 1.3+. You can build certstrap from source:
+certstrap must be built with Go 1.4+. You can build certstrap from source:
 
 ```
 $ git clone https://github.com/square/certstrap

--- a/pkix/cert_auth.go
+++ b/pkix/cert_auth.go
@@ -59,9 +59,7 @@ var (
 		// activate CA
 		BasicConstraintsValid: true,
 		IsCA: true,
-		// Not allow any non-self-issued intermediate CA
-		MaxPathLen: 0,
-		// Must be true if MaxPathLen==0
+		// Not allow any non-self-issued intermediate CA, sets MaxPathLen=0
 		MaxPathLenZero: true,
 
 		// 160-bit SHA-1 hash of the value of the BIT STRING subjectPublicKey

--- a/pkix/cert_auth.go
+++ b/pkix/cert_auth.go
@@ -61,6 +61,8 @@ var (
 		IsCA: true,
 		// Not allow any non-self-issued intermediate CA
 		MaxPathLen: 0,
+		// Must be true if MaxPathLen==0
+		MaxPathLenZero: true,
 
 		// 160-bit SHA-1 hash of the value of the BIT STRING subjectPublicKey
 		// (excluding the tag, length, and number of unused bits)


### PR DESCRIPTION
Addresses #7: properly sets MaxPathLenZero to true to comply with x509 api

It seems like Go1.3 does not have the MaxPathLenZero field in its x509.Certificate, however.

R: @sul3n3t