### PR TITLE
Add out to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 gopath
 bin
+out


### PR DESCRIPTION
To avoid even the slightest chance anyone would commit the generated certs to their copy/fork.