### PR TITLE
fix IP string conversion, add workflow test with only ip address

### DIFF
--- a/cmd/request_cert.go
+++ b/cmd/request_cert.go
@@ -68,7 +68,7 @@ func newCertAction(c *cli.Context) {
 	case len(domains) != 0:
 		name = domains[0]
 	case len(ips) != 0:
-		name = string(ips[0])
+		name = ips[0].String()
 	default:
 		fmt.Fprintln(os.Stderr, "Must provide Common Name or SAN")
 		os.Exit(1)

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -45,6 +45,14 @@ func TestWorkflow(t *testing.T) {
 		t.Fatalf("Received insufficient create: %v", stdout)
 	}
 
+	stdout, stderr, err = run(binPath, "request-cert", "--passphrase", passphrase, "--ip", "127.0.0.1,8.8.8.8")
+	if stderr != "" || err != nil {
+		t.Fatalf("Received unexpected error: %v, %v", stderr, err)
+	}
+	if strings.Count(stdout, "Created") != 2 {
+		t.Fatalf("Received insufficient create: %v", stdout)
+	}
+
 	stdout, stderr, err = run(binPath, "sign", "--passphrase", passphrase, "--CA", "CA", hostname)
 	if stderr != "" || err != nil {
 		t.Fatalf("Received unexpected error: %v, %v", stderr, err)


### PR DESCRIPTION
Fix for #12

Uses the built-in go method to convert net.IP to properly encoded string type, adds test to ensure that -ip flag behaves as expected