### PR TITLE
Throw an error if a supplied IP is invalid

### DIFF
--- a/cmd/request_cert.go
+++ b/cmd/request_cert.go
@@ -59,7 +59,7 @@ func newCertAction(c *cli.Context) {
 	ips, err := pkix.ParseAndValidateIPs(c.String("ip"))
 
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Invalid IP address:", err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 

--- a/cmd/request_cert.go
+++ b/cmd/request_cert.go
@@ -56,6 +56,7 @@ func newCertAction(c *cli.Context) {
 	var name = ""
 	var err error
 
+	// The CLI Context returns an empty string ("") if no value is available
 	ips, err := pkix.ParseAndValidateIPs(c.String("ip"))
 
 	if err != nil {

--- a/cmd/request_cert.go
+++ b/cmd/request_cert.go
@@ -54,8 +54,14 @@ func NewCertRequestCommand() cli.Command {
 
 func newCertAction(c *cli.Context) {
 	var name = ""
+	var err error
 
-	ips := pkix.ParseAndValidateIPs(c.String("ip"))
+	ips, err := pkix.ParseAndValidateIPs(c.String("ip"))
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Invalid IP address:", err)
+		os.Exit(1)
+	}
 
 	domains := strings.Split(c.String("domain"), ",")
 	if c.String("domain") == "" {
@@ -82,7 +88,6 @@ func newCertAction(c *cli.Context) {
 	}
 
 	var passphrase []byte
-	var err error
 	if c.IsSet("passphrase") {
 		passphrase = []byte(c.String("passphrase"))
 	} else {

--- a/pkix/csr.go
+++ b/pkix/csr.go
@@ -31,6 +31,7 @@ import (
 	"math/big"
 	"net"
 	"strings"
+	"fmt"
 )
 
 const (
@@ -58,7 +59,7 @@ func ParseAndValidateIPs(ipList string) (res []net.IP, err error) {
 		if len(ip) > 0 {
 			parsedIP := net.ParseIP(ip)
 			if parsedIP == nil {
-				return nil, errors.New(ip)
+				return nil, errors.New(fmt.Sprintf("Invalid IP address: %s", ip))
 			}
 			res = append(res, parsedIP)
 		}

--- a/pkix/csr.go
+++ b/pkix/csr.go
@@ -28,10 +28,10 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"math/big"
 	"net"
 	"strings"
-	"fmt"
 )
 
 const (
@@ -54,9 +54,10 @@ var (
 
 // ParseAndValidateIPs parses a comma-delimited list of IP addresses into an array of IP addresses
 func ParseAndValidateIPs(ipList string) (res []net.IP, err error) {
-	ips := strings.Split(ipList, ",")
-	for _, ip := range ips {
-		if len(ip) > 0 {
+	// IP list can potentially be a blank string, ""
+	if len(ipList) > 0 {
+		ips := strings.Split(ipList, ",")
+		for _, ip := range ips {
 			parsedIP := net.ParseIP(ip)
 			if parsedIP == nil {
 				return nil, errors.New(fmt.Sprintf("Invalid IP address: %s", ip))

--- a/pkix/csr.go
+++ b/pkix/csr.go
@@ -52,14 +52,16 @@ var (
 )
 
 // ParseAndValidateIPs parses a comma-delimited list of IP addresses into an array of IP addresses
-func ParseAndValidateIPs(ipList string) (res []net.IP) {
+func ParseAndValidateIPs(ipList string) (res []net.IP, err error) {
 	ips := strings.Split(ipList, ",")
 	for _, ip := range ips {
-		parsedIP := net.ParseIP(ip)
-		if parsedIP == nil {
-			return nil
+		if len(ip) > 0 {
+			parsedIP := net.ParseIP(ip)
+			if parsedIP == nil {
+				return nil, errors.New(ip)
+			}
+			res = append(res, parsedIP)
 		}
-		res = append(res, parsedIP)
 	}
 	return
 }

--- a/tests/ip_test.go
+++ b/tests/ip_test.go
@@ -1,0 +1,62 @@
+/*-
+ * Copyright 2015 Square Inc.
+ * Copyright 2014 CoreOS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tests
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Tests IP validation
+func TestIp(t *testing.T) {
+	os.RemoveAll(depotDir)
+	defer os.RemoveAll(depotDir)
+
+	stdout, stderr, err := run(binPath, "request-cert", "--passphrase", passphrase, "--common-name", "CA", "--ip", "192.168.0.1")
+	if stderr != "" || err != nil {
+		t.Fatalf("Received unexpected error: %v, %v", stderr, err)
+	}
+	if strings.Count(stdout, "Created") != 2 {
+		t.Fatalf("Received incorrect create: %v", stdout)
+	}
+
+	os.RemoveAll(depotDir)
+	defer os.RemoveAll(depotDir)
+
+	stdout, stderr, err = run(binPath, "request-cert", "--passphrase", passphrase, "--common-name", "CA", "--ip", "192.168.0.1,8.8.8.8")
+	if stderr != "" || err != nil {
+		t.Fatalf("Received unexpected error: %v, %v", stderr, err)
+	}
+	if strings.Count(stdout, "Created") != 2 {
+		t.Fatalf("Received incorrect create: %v", stdout)
+	}
+
+	os.RemoveAll(depotDir)
+	defer os.RemoveAll(depotDir)
+
+	stdout, stderr, err = run(binPath, "request-cert", "--passphrase", passphrase, "--common-name", "CA", "--ip", "foo")
+	if !strings.Contains(stderr, "Invalid IP address: foo") {
+		t.Fatalf("Received unexpected : %v, %v", stderr, err)
+	}
+
+	stdout, stderr, err = run(binPath, "request-cert", "--passphrase", passphrase, "--common-name", "CA", "--ip", "192.168.0.1,8.8.8.8,bar,1.2.3.4")
+	if !strings.Contains(stderr, "Invalid IP address: bar") {
+		t.Fatalf("Received unexpected : %v, %v", stderr, err)
+	}
+}


### PR DESCRIPTION
If an invalid IP occurs in the list supplied to the `--ip` flag, an error will be shown to the user (Invalid IP address: `<invalid-ip>`) and the program will exit with status code 1.

Please yell at me if there is anything that can be done in a better fashion. As noted earlier, I'm fairly fresh to the world of Go.