### PR TITLE
Add Go 1.8, drop 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: go
 sudo: false
 
 go:
-- 1.4
 - 1.5
+- 1.8
 - tip
 
 install:


### PR DESCRIPTION
1.4 is pretty old, so no harm in dropping it I think.