### PR TITLE
Adds github release publishing from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,24 @@
 language: go
-
 sudo: false
-
 go:
 - 1.5
 - 1.8
 - tip
-
+deploy:
+  provider: releases
+  api_key: $GITHUB_TOKEN
+  file:
+  - bin/certstrap-${TRAVIS_TAG}-linux-amd64
+  - bin/certstrap-${TRAVIS_TAG}-darwin-amd64
+  - bin/certstrap-${TRAVIS_TAG}-windows-amd64
+  skip_cleanup: true
+  on:
+    tags: true
+    go: 1.8
 install:
 - go get -d -t -v ./...
 - go get github.com/tools/godep
-
 before_script:
 - ./build
-
 script:
 - ./test

--- a/build
+++ b/build
@@ -4,6 +4,7 @@
 
 ORG_PATH="github.com/square"
 REPO_PATH="${ORG_PATH}/certstrap"
+BUILD_TAG="${TRAVIS_TAG:-$(git describe --all | sed -e's/.*\///g')}"
 
 export GOPATH=${PWD}/gopath
 
@@ -13,4 +14,6 @@ ln -s ${PWD} $GOPATH/src/${REPO_PATH}
 
 eval $(go env)
 
-go build -o bin/certstrap ${REPO_PATH}
+GOARCH=amd64 GOOS=linux go build -o bin/certstrap-${BUILD_TAG}-linux-amd64 ${REPO_PATH}
+GOARCH=amd64 GOOS=darwin go build -o bin/certstrap-${BUILD_TAG}-darwin-amd64 ${REPO_PATH}
+GOARCH=amd64 GOOS=windows go build -o bin/certstrap-${BUILD_TAG}-windows-amd64 ${REPO_PATH}

--- a/test
+++ b/test
@@ -8,6 +8,8 @@ if [ -z "$PKG" ]; then
     PKG="depot pkix tests"
 fi
 
+export BUILD_TAG="${TRAVIS_TAG:-$(git describe --all | sed -e's/.*\///g')}"
+
 # Unit tests
 echo
 for mod in $PKG; do

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -23,14 +23,18 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"runtime"
+	"fmt"
+	"os"
 )
 
 const (
-	binPath    = "../bin/certstrap"
-	depotDir   = ".certstrap-test"
-	hostname   = "host1"
-	passphrase = "123456"
+	depotDir         = ".certstrap-test"
+	hostname         = "host1"
+	passphrase       = "123456"
 )
+
+var binPath = fmt.Sprintf("../bin/certstrap-%s-%s-amd64", os.Getenv("BUILD_TAG"), runtime.GOOS)
 
 func run(command string, args ...string) (string, string, error) {
 	var stdoutBytes, stderrBytes bytes.Buffer


### PR DESCRIPTION
Implements https://github.com/square/certstrap/issues/31

Someone with admin access to the certstrap repo will need to create a personal access token on github with the "repo" scope and add it to the certstrap travis job as an env var called GITHUB_TOKEN making sure it is not displayed when you add it.

Alternatively you can implement it as an encrypted travis var but I have had issues getting that working.

Due to building all three binaries on travis and changing the binary name some of the scripts needed modification.