### PR TITLE
2nd try: Adds out-name cli option

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -46,6 +46,7 @@ func NewInitCommand() cli.Command {
 			cli.StringFlag{"province, st", "", "CA state/province", ""},
 			cli.StringFlag{"locality, l", "", "CA locality", ""},
 			cli.StringFlag{"key", "", "Path to private key PEM file.  If blank, will generate new keypair.", ""},
+			cli.StringFlag{"out-name, on", "", "Name for output files without path and extension. If blank, CA common name will be used.", ""},
 			cli.BoolFlag{"stdout", "Print CA certificate to stdout in addition to saving file", ""},
 		},
 		Action: initAction,
@@ -60,6 +61,9 @@ func initAction(c *cli.Context) {
 	}
 
 	formattedName := strings.Replace(c.String("common-name"), " ", "_", -1)
+	if c.IsSet("out-name") {
+		formattedName = strings.Replace(c.String("out-name"), " ", "_", -1)
+	}
 
 	if depot.CheckCertificate(d, formattedName) || depot.CheckPrivateKey(d, formattedName) {
 		fmt.Fprintln(os.Stderr, "CA with specified name already exists!")

--- a/cmd/request_cert.go
+++ b/cmd/request_cert.go
@@ -46,6 +46,7 @@ func NewCertRequestCommand() cli.Command {
 			cli.StringFlag{"ip", "", "IP address entries for subject alt name (comma separated)", ""},
 			cli.StringFlag{"domain", "", "DNS entries for subject alt name (comma separated)", ""},
 			cli.StringFlag{"key", "", "Path to private key PEM file.  If blank, will generate new keypair.", ""},
+			cli.StringFlag{"out-name, on", "", "Name for output files without path and extension. If blank, Common name will be used.", ""},
 			cli.BoolFlag{"stdout", "Print signing request to stdout in addition to saving file", ""},
 		},
 		Action: newCertAction,
@@ -82,6 +83,9 @@ func newCertAction(c *cli.Context) {
 	}
 
 	formattedName := strings.Replace(name, " ", "_", -1)
+	if c.IsSet("out-name") {
+		formattedName = strings.Replace(c.String("out-name"), " ", "_", -1)
+	}
 
 	if depot.CheckCertificateSigningRequest(d, formattedName) || depot.CheckPrivateKey(d, formattedName) {
 		fmt.Fprintln(os.Stderr, "Certificate request has existed!")


### PR DESCRIPTION
Pull request #52 was closed because I made a lot of changes in cloned master while this request was open. Sorry for that! So this is the next try - now based on a branch. You can decide if it is worth to merge. I made my changes in my clone of your great work now (also experimental PFX export).

Original comment of #52:
>I needed such a solution for better script processing with predefined output names (which can differ from cn or domain)