### PR TITLE
Add support for EKUs (and fix ./test)

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -69,7 +69,7 @@ func initAction(c *cli.Context) {
 	var err error
 	expires := c.String("expires")
 	if years := c.Int("years"); years != 0 {
-		expires = fmt.Sprintf("%s %s years", expires, years)
+		expires = fmt.Sprintf("%s %d years", expires, years)
 	}
 
 	// Expiry parsing is a naive regex implementation

--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -61,7 +61,7 @@ func newSignAction(c *cli.Context) {
 
 	expires := c.String("expires")
 	if years := c.Int("years"); years != 0 {
-		expires = fmt.Sprintf("%s %s years", expires, years)
+		expires = fmt.Sprintf("%s %d years", expires, years)
 	}
 
 	// Expiry parsing is a naive regex implementation

--- a/pkix/cert_auth.go
+++ b/pkix/cert_auth.go
@@ -145,6 +145,8 @@ func CreateIntermediateCertificateAuthority(crtAuth *Certificate, keyAuth *Key, 
 	authTemplate.IPAddresses = rawCsr.IPAddresses
 	authTemplate.DNSNames = rawCsr.DNSNames
 
+	authTemplate.ExtraExtensions = rawCsr.Extensions
+
 	rawCrtAuth, err := crtAuth.GetRawCertificate()
 	if err != nil {
 		return nil, err

--- a/pkix/cert_host.go
+++ b/pkix/cert_host.go
@@ -96,6 +96,8 @@ func CreateCertificateHost(crtAuth *Certificate, keyAuth *Key, csr *CertificateS
 	hostTemplate.IPAddresses = rawCsr.IPAddresses
 	hostTemplate.DNSNames = rawCsr.DNSNames
 
+	hostTemplate.ExtraExtensions = rawCsr.Extensions
+
 	rawCrtAuth, err := crtAuth.GetRawCertificate()
 	if err != nil {
 		return nil, err

--- a/pkix/csr.go
+++ b/pkix/csr.go
@@ -70,7 +70,7 @@ func ParseAndValidateIPs(ipList string) (res []net.IP, err error) {
 }
 
 // CreateCertificateSigningRequest sets up a request to create a csr file with the given parameters
-func CreateCertificateSigningRequest(key *Key, organizationalUnit string, ipList []net.IP, domainList []string, organization string, country string, province string, locality string, commonName string) (*CertificateSigningRequest, error) {
+func CreateCertificateSigningRequest(key *Key, organizationalUnit string, ipList []net.IP, domainList []string, organization string, country string, province string, locality string, commonName string, extensions *[]pkix.Extension) (*CertificateSigningRequest, error) {
 
 	csrPkixName.CommonName = commonName
 
@@ -93,6 +93,9 @@ func CreateCertificateSigningRequest(key *Key, organizationalUnit string, ipList
 		Subject:     csrPkixName,
 		IPAddresses: ipList,
 		DNSNames:    domainList,
+	}
+	if extensions != nil {
+		(*csrTemplate).ExtraExtensions = *extensions
 	}
 
 	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, key.Private)

--- a/pkix/csr_test.go
+++ b/pkix/csr_test.go
@@ -79,7 +79,7 @@ func TestCreateCertificateSigningRequest(t *testing.T) {
 		t.Fatal("Failed creating rsa key:", err)
 	}
 
-	csr, err := CreateCertificateSigningRequest(key, csrHostname, nil, nil, "example", "US", "California", "San Francisco", csrCN)
+	csr, err := CreateCertificateSigningRequest(key, csrHostname, nil, nil, "example", "US", "California", "San Francisco", csrCN, nil)
 	if err != nil {
 		t.Fatal("Failed creating certificate request:", err)
 	}


### PR DESCRIPTION
Add a parameter to support issuing certificates with custom EKUs. (Use case: I need to issue certificates with BitLocker OIDs in the EKU extension.) I hope to extend this in the future to include shorthand strings for common EKUs, like OpenSSL's `clientAuth` and `serverAuth` keywords. This code also provides a nice place for future development to add arbitrary extensions of any type, right before `cmd/request_cert.go:177`.

(Also, fixes a couple format string errors preventing `./test` from working.)