### PR TITLE
Simplify s[:] to s where s is a slice

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -126,7 +126,7 @@ func initAction(c *cli.Context) {
 			fmt.Fprintln(os.Stderr, "Print CA certificate error:", err)
 			os.Exit(1)
 		} else {
-			fmt.Printf(string(crtBytes[:]))
+			fmt.Printf(string(crtBytes))
 		}
 	}
 

--- a/cmd/request_cert.go
+++ b/cmd/request_cert.go
@@ -135,7 +135,7 @@ func newCertAction(c *cli.Context) {
 			fmt.Fprintln(os.Stderr, "Print certificate request error:", err)
 			os.Exit(1)
 		} else {
-			fmt.Printf(string(csrBytes[:]))
+			fmt.Printf(string(csrBytes))
 		}
 	}
 

--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -126,7 +126,7 @@ func newSignAction(c *cli.Context) {
 			fmt.Fprintln(os.Stderr, "Print certificate error:", err)
 			os.Exit(1)
 		} else {
-			fmt.Printf(string(crtBytes[:]))
+			fmt.Printf(string(crtBytes))
 		}
 	}
 


### PR DESCRIPTION
Found using https://go-critic.github.io/overview#unslice-ref