### PR TITLE
Allow setting NotBefore property via init and sign commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ certstrap can init multiple certificate authorities to sign certificates with.  
 
 ### Building
 
-certstrap must be built with Go 1.4+. You can build certstrap from source:
+certstrap must be built with Go 1.11+. You can build certstrap from source:
 
 ```
 $ git clone https://github.com/square/certstrap

--- a/cmd/expiry.go
+++ b/cmd/expiry.go
@@ -9,11 +9,10 @@ import (
 
 var nowFunc = time.Now
 
-func parseExpiry(fromNow string) (time.Time, error) {
-	now := nowFunc().UTC()
+func parseTime(timeString string) (map[string]int, error) {
 	re := regexp.MustCompile("\\s*(\\d+)\\s*(day|month|year|hour)s?")
-	matches := re.FindAllStringSubmatch(fromNow, -1)
-	addDate := map[string]int{
+	matches := re.FindAllStringSubmatch(timeString, -1)
+	date := map[string]int{
 		"day":   0,
 		"month": 0,
 		"year":  0,
@@ -22,15 +21,25 @@ func parseExpiry(fromNow string) (time.Time, error) {
 	for _, r := range matches {
 		number, err := strconv.ParseInt(r[1], 10, 32)
 		if err != nil {
-			return now, err
+			return nil, err
 		}
-		addDate[r[2]] = int(number)
+		date[r[2]] = int(number)
 	}
 
 	// Ensure that we do not overflow time.Duration.
 	// Doing so is silent and causes signed integer overflow like issues.
-	if _, err := time.ParseDuration(fmt.Sprintf("%dh", addDate["hour"])); err != nil {
-		return now, fmt.Errorf("hour unit too large to process")
+	if _, err := time.ParseDuration(fmt.Sprintf("%dh", date["hour"])); err != nil {
+		return nil, fmt.Errorf("hour unit too large to process")
+	}
+
+	return date, nil
+}
+
+func parseExpiry(fromNow string) (time.Time, error) {
+	now := nowFunc().UTC()
+	addDate, err := parseTime(fromNow)
+	if err != nil {
+		return now, err
 	}
 
 	result := now.
@@ -45,6 +54,36 @@ func parseExpiry(fromNow string) (time.Time, error) {
 	// https://www.openssl.org/docs/man1.1.0/crypto/ASN1_TIME_check.html
 	if result.Year() > 9999 {
 		return now, fmt.Errorf("proposed date too far in to the future: %s. Expiry year must be less than or equal to 9999", result)
+	}
+
+	return result, nil
+}
+
+func parseNotBefore(notBefore string) (time.Time, error) {
+	now := nowFunc().UTC()
+	tenMinutesAgo := nowFunc().Add(-time.Minute * 10).UTC()
+
+	subDate, err := parseTime(notBefore)
+	if err != nil {
+		return tenMinutesAgo, err
+	}
+
+	for unitOfTime, value := range subDate {
+		subDate[unitOfTime] = -value
+	}
+
+	result := now.
+		AddDate(subDate["year"], subDate["month"], subDate["day"]).
+		Add(time.Duration(subDate["hour"]) * time.Hour)
+
+	if now == result {
+		return tenMinutesAgo, fmt.Errorf("invalid or empty format")
+	}
+
+	// ASN.1 (encoding format used by SSL) can support down to year 0
+	// https://www.openssl.org/docs/man1.1.0/crypto/ASN1_TIME_check.html
+	if result.Year() < 0 {
+		return tenMinutesAgo, fmt.Errorf("proposed date too far in to the past: %s. Expiry year must be greater than or equal to 0", result)
 	}
 
 	return result, nil

--- a/cmd/expiry_test.go
+++ b/cmd/expiry_test.go
@@ -99,6 +99,47 @@ func TestParseInvalidExpiry(t *testing.T) {
 	}
 }
 
+func TestParseNotBeforeWithMixed(t *testing.T) {
+	t1, _ := parseNotBefore("2 days 3 months 1 year")
+	t2, _ := parseNotBefore("5 years 5 days 6 months")
+	expectedt1, _ := time.Parse(dateFormat, "2015-09-29")
+	expectedt2, _ := time.Parse(dateFormat, "2011-06-26")
+
+	if t1 != expectedt1 {
+		t.Fatalf("Parsing notbefore for mixed format t1 did not return expected value (wanted: %s, got: %s)", expectedt1, t1)
+	}
+
+	if t2 != expectedt2 {
+		t.Fatalf("Parsing notbefore for mixed format t2 did not return expected value (wanted: %s, got: %s)", expectedt2, t2)
+	}
+}
+
+func TestParseInvalidNotBefore(t *testing.T) {
+	errorTime := onlyTime(time.Parse("2006-01-02 15:04:05", "2016-12-31 23:50:00"))
+	cases := []struct {
+		Input       string
+		Expected    time.Time
+		ExpectedErr string
+	}{
+		{"53257284647843897", errorTime, "invalid or empty format"},
+		{"5y", errorTime, "invalid or empty format"},
+		{"53257284647843897 days", errorTime, ".*value out of range"},
+		{"2147483647 hours", errorTime, ".*hour unit too large.*"},
+		{"2147483647 days", errorTime, ".*proposed date too far in to the past.*"},
+	}
+
+	for _, c := range cases {
+		result, err := parseNotBefore(c.Input)
+		if result != c.Expected {
+			t.Fatalf("Invalid notbefore '%s' did not have expected value (wanted: %s, got: %s)", c.Input, c.Expected, result)
+		}
+
+		if match, _ := regexp.MatchString(c.ExpectedErr, fmt.Sprintf("%s", err)); !match {
+			t.Fatalf("Invalid notbefore '%s' did not have expected error (wanted: %s, got: %s)", c.Input, c.ExpectedErr, err)
+		}
+	}
+}
+
 func onlyTime(a time.Time, b error) time.Time {
 	return a
 }

--- a/cmd/revoke_test.go
+++ b/cmd/revoke_test.go
@@ -73,7 +73,7 @@ func setupCA(t *testing.T, dt depot.Depot) {
 	}
 
 	// create certificate authority
-	caCert, err := pkix.CreateCertificateAuthority(key, caName, time.Now().Add(1*time.Minute), "", "", "", "", caName)
+	caCert, err := pkix.CreateCertificateAuthority(key, caName, time.Now().Add(1*time.Minute), time.Now().Add(-time.Minute*10).UTC(), "", "", "", "", caName)
 	if err != nil {
 		t.Fatalf("could not create authority cert: %v", err)
 	}

--- a/pkix/cert_auth_test.go
+++ b/pkix/cert_auth_test.go
@@ -28,7 +28,7 @@ func TestCreateCertificateAuthority(t *testing.T) {
 		t.Fatal("Failed creating rsa key:", err)
 	}
 
-	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name")
+	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), time.Now().Add(-time.Minute*10).UTC(), "test", "US", "California", "San Francisco", "CA Name")
 	if err != nil {
 		t.Fatal("Failed creating certificate authority:", err)
 	}

--- a/pkix/cert_host.go
+++ b/pkix/cert_host.go
@@ -33,7 +33,7 @@ var (
 		// **SHOULD** be filled in host info
 		Subject: pkix.Name{},
 		// NotBefore is set to be 10min earlier to fix gap on time difference in cluster
-		NotBefore: time.Now().Add(-600).UTC(),
+		NotBefore: time.Now().Add(-time.Minute * 10).UTC(),
 		// 10-year lease
 		NotAfter: time.Time{},
 		// Used for certificate signing only

--- a/pkix/crl_test.go
+++ b/pkix/crl_test.go
@@ -49,7 +49,7 @@ func TestCreateCertificateRevocationList(t *testing.T) {
 		t.Fatal("Failed creating rsa key:", err)
 	}
 
-	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name")
+	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), time.Now().Add(-time.Minute*10).UTC(), "test", "US", "California", "San Francisco", "CA Name")
 	if err != nil {
 		t.Fatal("Failed creating certificate authority:", err)
 	}


### PR DESCRIPTION
Adds `notbefore` as an argument to `init` and `sign` to allow setting NotBefore property. If `notbefore` is not supplied, the `NotBefore` will be set as 10 minutes earlier than now. I believe this was intended to be the default behavior before, e.g.
```
// NotBefore is set to be 10min earlier to fix gap on time difference in cluster
NotBefore: time.Now().Add(-600).UTC(),
```
However, `Add` takes a `Duration` as an argument, which is an `int64` representing nanoseconds - so I don't think this behaved as described by the comment. I've changed the argument to `-time.Minute * 10`. Let me know if I should keep it as-is.
