### PR TITLE
cmd: Make errors from existing CA/CSR/Cert paths more explicit

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -99,7 +99,7 @@ func initAction(c *cli.Context) {
 	formattedName := strings.Replace(c.String("common-name"), " ", "_", -1)
 
 	if depot.CheckCertificate(d, formattedName) || depot.CheckPrivateKey(d, formattedName) {
-		fmt.Fprintln(os.Stderr, "CA with specified name already exists!")
+		fmt.Fprintf(os.Stderr, "CA with specified name \"%s\" already exists!\n", formattedName)
 		os.Exit(1)
 	}
 

--- a/cmd/request_cert.go
+++ b/cmd/request_cert.go
@@ -132,7 +132,7 @@ func newCertAction(c *cli.Context) {
 	var formattedName = formatName(name)
 
 	if depot.CheckCertificateSigningRequest(d, formattedName) || depot.CheckPrivateKey(d, formattedName) {
-		fmt.Fprintln(os.Stderr, "Certificate request has existed!")
+		fmt.Fprintf(os.Stderr, "Certificate request \"%s\" already exists!\n", formattedName)
 		os.Exit(1)
 	}
 

--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -74,7 +74,7 @@ func newSignAction(c *cli.Context) {
 	formattedCAName := strings.Replace(c.String("CA"), " ", "_", -1)
 
 	if depot.CheckCertificate(d, formattedReqName) {
-		fmt.Fprintln(os.Stderr, "Certificate has existed!")
+		fmt.Fprintf(os.Stderr, "Certificate \"%s\" already exists!\n", formattedReqName)
 		os.Exit(1)
 	}
 
@@ -131,7 +131,7 @@ func newSignAction(c *cli.Context) {
 
 	var crtOut *pkix.Certificate
 	if c.Bool("intermediate") {
-		fmt.Fprintf(os.Stderr, "Building intermediate")
+		fmt.Fprintln(os.Stderr, "Building intermediate")
 		crtOut, err = pkix.CreateIntermediateCertificateAuthority(crt, key, csr, expiresTime)
 	} else {
 		crtOut, err = pkix.CreateCertificateHost(crt, key, csr, expiresTime)


### PR DESCRIPTION
Spent some time debugging an issue with certificate generation during
tests and outputing the conflicting names helped. Also adds line
breaking on an error condition for the 'sign' command.