### PR TITLE
Create new x509 templates

### DIFF
--- a/pkix/cert_auth.go
+++ b/pkix/cert_auth.go
@@ -20,64 +20,15 @@ package pkix
 import (
 	"crypto/rand"
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"math/big"
 	"time"
-)
-
-const (
-	// hostname used by CA certificate
-	// SerialNumber to start when signing certificate request
-	authStartSerialNumber = 2
-)
-
-var (
-	authPkixName = pkix.Name{
-		Country:            nil,
-		Organization:       nil,
-		OrganizationalUnit: nil,
-		Locality:           nil,
-		Province:           nil,
-		StreetAddress:      nil,
-		PostalCode:         nil,
-		SerialNumber:       "",
-		CommonName:         "",
-	}
-	// Build CA based on RFC5280
-	authTemplate = x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject:      authPkixName,
-		// NotBefore is set to be 10min earlier to fix gap on time difference in cluster
-		NotBefore: time.Now().Add(-600).UTC(),
-		NotAfter:  time.Time{},
-		// Used for certificate signing only
-		KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-
-		ExtKeyUsage:        nil,
-		UnknownExtKeyUsage: nil,
-
-		// activate CA
-		BasicConstraintsValid: true,
-		IsCA: true,
-		// Not allow any non-self-issued intermediate CA, sets MaxPathLen=0
-		MaxPathLenZero: true,
-
-		// 160-bit SHA-1 hash of the value of the BIT STRING subjectPublicKey
-		// (excluding the tag, length, and number of unused bits)
-		// **SHOULD** be filled in later
-		SubjectKeyId: nil,
-
-		// Subject Alternative Name
-		DNSNames: nil,
-
-		PermittedDNSDomainsCritical: false,
-		PermittedDNSDomains:         nil,
-	}
 )
 
 // CreateCertificateAuthority creates Certificate Authority using existing key.
 // CertificateAuthorityInfo returned is the extra infomation required by Certificate Authority.
 func CreateCertificateAuthority(key *Key, organizationalUnit string, expiry time.Time, organization string, country string, province string, locality string, commonName string) (*Certificate, error) {
+	authTemplate := newAuthTemplate()
+
 	subjectKeyID, err := GenerateSubjectKeyID(key.Public)
 	if err != nil {
 		return nil, err
@@ -114,6 +65,8 @@ func CreateCertificateAuthority(key *Key, organizationalUnit string, expiry time
 // CreateIntermediateCertificateAuthority creates an intermediate
 // CA certificate signed by the given authority.
 func CreateIntermediateCertificateAuthority(crtAuth *Certificate, keyAuth *Key, csr *CertificateSigningRequest, proposedExpiry time.Time) (*Certificate, error) {
+	authTemplate := newAuthTemplate()
+
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
@@ -157,4 +110,36 @@ func CreateIntermediateCertificateAuthority(crtAuth *Certificate, keyAuth *Key, 
 	}
 
 	return NewCertificateFromDER(crtOutBytes), nil
+}
+
+func newAuthTemplate() x509.Certificate {
+	// Build CA based on RFC5280
+	return x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		// NotBefore is set to be 10min earlier to fix gap on time difference in cluster
+		NotBefore: time.Now().Add(-600).UTC(),
+		NotAfter:  time.Time{},
+		// Used for certificate signing only
+		KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+
+		ExtKeyUsage:        nil,
+		UnknownExtKeyUsage: nil,
+
+		// activate CA
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		// Not allow any non-self-issued intermediate CA, sets MaxPathLen=0
+		MaxPathLenZero: true,
+
+		// 160-bit SHA-1 hash of the value of the BIT STRING subjectPublicKey
+		// (excluding the tag, length, and number of unused bits)
+		// **SHOULD** be filled in later
+		SubjectKeyId: nil,
+
+		// Subject Alternative Name
+		DNSNames: nil,
+
+		PermittedDNSDomainsCritical: false,
+		PermittedDNSDomains:         nil,
+	}
 }

--- a/pkix/cert_host.go
+++ b/pkix/cert_host.go
@@ -25,9 +25,11 @@ import (
 	"time"
 )
 
-var (
+// CreateCertificateHost creates certificate for host.
+// The arguments include CA certificate, CA key, certificate request.
+func CreateCertificateHost(crtAuth *Certificate, keyAuth *Key, csr *CertificateSigningRequest, proposedExpiry time.Time) (*Certificate, error) {
 	// Build CA based on RFC5280
-	hostTemplate = x509.Certificate{
+	hostTemplate := x509.Certificate{
 		// **SHOULD** be filled in a unique number
 		SerialNumber: big.NewInt(0),
 		// **SHOULD** be filled in host info
@@ -58,11 +60,7 @@ var (
 		PermittedDNSDomainsCritical: false,
 		PermittedDNSDomains:         nil,
 	}
-)
 
-// CreateCertificateHost creates certificate for host.
-// The arguments include CA certificate, CA key, certificate request.
-func CreateCertificateHost(crtAuth *Certificate, keyAuth *Key, csr *CertificateSigningRequest, proposedExpiry time.Time) (*Certificate, error) {
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {

--- a/pkix/csr.go
+++ b/pkix/csr.go
@@ -40,20 +40,6 @@ const (
 	oldCsrPEMBlockType = "NEW CERTIFICATE REQUEST"
 )
 
-var (
-	csrPkixName = pkix.Name{
-		Country:            []string{},
-		Organization:       []string{},
-		OrganizationalUnit: nil,
-		Locality:           nil,
-		Province:           nil,
-		StreetAddress:      nil,
-		PostalCode:         nil,
-		SerialNumber:       "",
-		CommonName:         "",
-	}
-)
-
 // ParseAndValidateIPs parses a comma-delimited list of IP addresses into an array of IP addresses
 func ParseAndValidateIPs(ipList string) (res []net.IP, err error) {
 	// IP list can potentially be a blank string, ""
@@ -93,8 +79,7 @@ func ParseAndValidateURIs(uriList string) (res []*url.URL, err error) {
 
 // CreateCertificateSigningRequest sets up a request to create a csr file with the given parameters
 func CreateCertificateSigningRequest(key *Key, organizationalUnit string, ipList []net.IP, domainList []string, uriList []*url.URL, organization string, country string, province string, locality string, commonName string) (*CertificateSigningRequest, error) {
-
-	csrPkixName.CommonName = commonName
+	csrPkixName := pkix.Name{CommonName: commonName}
 
 	if len(organizationalUnit) > 0 {
 		csrPkixName.OrganizationalUnit = []string{organizationalUnit}


### PR DESCRIPTION
Hello,

I was doing some testing on a package I wrote that uses certstrap and noticed that when I use certain pkix package functions (CreateCertificateAuthority, CreateCertificateSigningRequest, etc.) data is persisted due to the use of a global variable as the certificate template. As far as I can tell, there is no need to presist data once a certificate is created and it causes a bug when I want to create a new certificate (if I omit a field that was previously filled in, the field from the last certificate will not get overwritten and persists with the new certificate). 

Hope this change is helpful!

Julian