### PR TITLE
Allow to override default file inputs and outputs

### DIFF
--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -51,6 +51,14 @@ func NewSignCommand() cli.Command {
 				Name:  "CA",
 				Usage: "Name of CA to issue cert with",
 			},
+			cli.StringFlag{
+				Name:  "csr",
+				Usage: "Path to certificate request PEM file (if blank, will use --depot-path and default name)",
+			},
+			cli.StringFlag{
+				Name:  "cert",
+				Usage: "Path to certificate output PEM file (if blank, will use --depot-path and default name)",
+			},
 			cli.BoolFlag{
 				Name:  "stdout",
 				Usage: "Print certificate to stdout in addition to saving file",
@@ -91,7 +99,7 @@ func newSignAction(c *cli.Context) {
 		os.Exit(1)
 	}
 
-	csr, err := depot.GetCertificateSigningRequest(d, formattedReqName)
+	csr, err := getCertificateSigningRequest(c, d, formattedReqName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Get certificate request error:", err)
 		os.Exit(1)
@@ -154,7 +162,7 @@ func newSignAction(c *cli.Context) {
 		}
 	}
 
-	if err = depot.PutCertificate(d, formattedReqName, crtOut); err != nil {
+	if err = putCertificate(c, d, formattedReqName, crtOut); err != nil {
 		fmt.Fprintln(os.Stderr, "Save certificate error:", err)
 	}
 }

--- a/depot/pkix.go
+++ b/depot/pkix.go
@@ -31,28 +31,28 @@ const (
 )
 
 const (
-	branchPerm = 0440
-	leafPerm   = 0444
+	BranchPerm = 0440
+	LeafPerm   = 0444
 )
 
 // CrtTag returns a tag corresponding to a certificate
 func CrtTag(prefix string) *Tag {
-	return &Tag{prefix + crtSuffix, leafPerm}
+	return &Tag{prefix + crtSuffix, LeafPerm}
 }
 
 // PrivKeyTag returns a tag corresponding to a private key
 func PrivKeyTag(prefix string) *Tag {
-	return &Tag{prefix + privKeySuffix, branchPerm}
+	return &Tag{prefix + privKeySuffix, BranchPerm}
 }
 
 // CsrTag returns a tag corresponding to a certificate signature request file
 func CsrTag(prefix string) *Tag {
-	return &Tag{prefix + csrSuffix, leafPerm}
+	return &Tag{prefix + csrSuffix, LeafPerm}
 }
 
 // CrlTag returns a tag corresponding to a certificate revocation list
 func CrlTag(prefix string) *Tag {
-	return &Tag{prefix + crlSuffix, leafPerm}
+	return &Tag{prefix + crlSuffix, LeafPerm}
 }
 
 // GetNameFromCrtTag returns the host name from a certificate file tag

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c h1:kQWxfPIHVLbgLzphqk3QUflDy9QdksZR4ygR807bpy0=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
-github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
-github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.21.0 h1:wYSSj06510qPIzGSua9ZqsncMmWE3Zr55KBERygyrxE=
 github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVUZZQ=
 golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85 h1:et7+NAX3lLIk5qUCTA9QelBjGE/NkhzYw/mhnr0s7nI=

--- a/vendor/github.com/urfave/cli/.travis.yml
+++ b/vendor/github.com/urfave/cli/.travis.yml
@@ -2,7 +2,7 @@ language: go
 sudo: false
 dist: trusty
 osx_image: xcode8.3
-go: 1.8.x
+go: 1.11.x
 
 os:
 - linux

--- a/vendor/github.com/urfave/cli/CHANGELOG.md
+++ b/vendor/github.com/urfave/cli/CHANGELOG.md
@@ -4,7 +4,28 @@
 
 ## [Unreleased]
 
-## 1.20.0 - 2017-08-10
+## [1.21.0] - 2019-08-02
+
+### Fixed
+
+* Fix using "slice" flag types with `EnvVar` in [urfave/cli/pull/687](https://github.com/urfave/cli/pull/687) via [@joshuarubin](https://github.com/joshuarubin)
+* Fix regression of `SkipFlagParsing` behavior in [urfave/cli/pull/697](https://github.com/urfave/cli/pull/697) via [@jszwedko](https://github.com/jszwedko)
+* Fix handling `ShortOptions` and `SkipArgReorder` in [urfave/cli/pull/686](https://github.com/urfave/cli/pull/686) via [@baude](https://github.com/baude)
+* Fix args reordering when bool flags are present in [urfave/cli/pull/712](https://github.com/urfave/cli/pull/712) via [@windler](https://github.com/windler)
+* Fix parsing of short options in [urfave/cli/pull/758](https://github.com/urfave/cli/pull/758) via [@vrothberg](https://github.com/vrothberg)
+
+### Added / Changed
+
+* Added _"required flags"_ support in [urfave/cli/pull/819](https://github.com/urfave/cli/pull/819) via [@lynncyrin](https://github.com/lynncyrin/)
+* Cleaned up help output in [urfave/cli/pull/664](https://github.com/urfave/cli/pull/664) via [@maguro](https://github.com/maguro)
+* Case is now considered when sorting strings in [urfave/cli/pull/676](https://github.com/urfave/cli/pull/676) via [@rliebz](https://github.com/rliebz)
+* Backport JSON `InputSource` to v1 in [urfave/cli/pull/598](https://github.com/urfave/cli/pull/598) via [@jszwedko](https://github.com/jszwedko)
+* Allow more customization of flag help strings in [urfave/cli/pull/661](https://github.com/urfave/cli/pull/661) via [@rliebz](https://github.com/rliebz)
+* Allow custom `ExitError` handler function in [urfave/cli/pull/628](https://github.com/urfave/cli/pull/628) via [@phinnaeus](https://github.com/phinnaeus)
+* Allow loading a variable from a file in [urfave/cli/pull/675](https://github.com/urfave/cli/pull/675) via [@jmccann](https://github.com/jmccann)
+* Allow combining short bool names in [urfave/cli/pull/684](https://github.com/urfave/cli/pull/684) via [@baude](https://github.com/baude)
+
+## [1.20.0] - 2017-08-10
 
 ### Fixed
 
@@ -407,7 +428,11 @@ signature of `func(*cli.Context) error`, as defined by `cli.ActionFunc`.
 ### Added
 - Initial implementation.
 
-[Unreleased]: https://github.com/urfave/cli/compare/v1.18.0...HEAD
+[Unreleased]: https://github.com/urfave/cli/compare/v1.21.0...HEAD
+[1.21.0]: https://github.com/urfave/cli/compare/v1.20.0...v1.21.0
+[1.20.0]: https://github.com/urfave/cli/compare/v1.19.1...v1.20.0
+[1.19.1]: https://github.com/urfave/cli/compare/v1.19.0...v1.19.1
+[1.19.0]: https://github.com/urfave/cli/compare/v1.18.0...v1.19.0
 [1.18.0]: https://github.com/urfave/cli/compare/v1.17.0...v1.18.0
 [1.17.0]: https://github.com/urfave/cli/compare/v1.16.0...v1.17.0
 [1.16.0]: https://github.com/urfave/cli/compare/v1.15.0...v1.16.0

--- a/vendor/github.com/urfave/cli/CODE_OF_CONDUCT.md
+++ b/vendor/github.com/urfave/cli/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting Dan Buch at dan@meatballhat.com. All complaints will be
+reviewed and investigated and will result in a response that is deemed necessary
+and appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident.  Further details of
+specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+

--- a/vendor/github.com/urfave/cli/CONTRIBUTING.md
+++ b/vendor/github.com/urfave/cli/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+## Contributing
+
+**NOTE**: the primary maintainer(s) may be found in
+[./MAINTAINERS.md](./MAINTAINERS.md).
+
+Feel free to put up a pull request to fix a bug or maybe add a feature. I will
+give it a code review and make sure that it does not break backwards
+compatibility. If I or any other collaborators agree that it is in line with
+the vision of the project, we will work with you to get the code into
+a mergeable state and merge it into the master branch.
+
+If you have contributed something significant to the project, we will most
+likely add you as a collaborator. As a collaborator you are given the ability
+to merge others pull requests. It is very important that new code does not
+break existing code, so be careful about what code you do choose to merge.
+
+If you feel like you have contributed to the project but have not yet been added
+as a collaborator, we probably forgot to add you :sweat_smile:.  Please open an
+issue!

--- a/vendor/github.com/urfave/cli/MAINTAINERS.md
+++ b/vendor/github.com/urfave/cli/MAINTAINERS.md
@@ -1,0 +1,4 @@
+- @meatballhat
+- @lynncyrin
+- @AudriusButkevicius
+- @asahasrabuddhe

--- a/vendor/github.com/urfave/cli/README.md
+++ b/vendor/github.com/urfave/cli/README.md
@@ -9,9 +9,9 @@ cli
 [![top level coverage](https://gocover.io/_badge/github.com/urfave/cli?0 "top level coverage")](http://gocover.io/github.com/urfave/cli) /
 [![altsrc coverage](https://gocover.io/_badge/github.com/urfave/cli/altsrc?0 "altsrc coverage")](http://gocover.io/github.com/urfave/cli/altsrc)
 
-**Notice:** This is the library formerly known as
-`github.com/codegangsta/cli` -- Github will automatically redirect requests
-to this repository, but we recommend updating your references for clarity.
+This is the library formerly known as `github.com/codegangsta/cli` -- Github
+will automatically redirect requests to this repository, but we recommend
+updating your references for clarity.
 
 cli is a simple, fast, and fun package for building command line apps in Go. The
 goal is to enable developers to write fast and distributable command line
@@ -32,7 +32,9 @@ applications in an expressive way.
     + [Alternate Names](#alternate-names)
     + [Ordering](#ordering)
     + [Values from the Environment](#values-from-the-environment)
+    + [Values from files](#values-from-files)
     + [Values from alternate input sources (YAML, TOML, and others)](#values-from-alternate-input-sources-yaml-toml-and-others)
+    + [Precedence](#precedence)
   * [Subcommands](#subcommands)
   * [Subcommands categories](#subcommands-categories)
   * [Exit code](#exit-code)
@@ -45,6 +47,7 @@ applications in an expressive way.
   * [Version Flag](#version-flag)
     + [Customization](#customization-2)
     + [Full API Example](#full-api-example)
+  * [Combining short Bool options](#combining-short-bool-options)
 - [Contribution Guidelines](#contribution-guidelines)
 
 <!-- tocstop -->
@@ -138,13 +141,17 @@ discovery. So a cli app can be as little as one line of code in `main()`.
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
 )
 
 func main() {
-  cli.NewApp().Run(os.Args)
+  err := cli.NewApp().Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -159,6 +166,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -173,7 +181,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -197,6 +208,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -211,7 +223,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -260,6 +275,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -273,7 +289,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -289,6 +308,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -318,7 +338,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -332,6 +355,7 @@ scanned.
 package main
 
 import (
+  "log"
   "os"
   "fmt"
 
@@ -365,7 +389,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -386,6 +413,7 @@ For example this:
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -401,7 +429,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -427,6 +458,7 @@ list for the `Name`. e.g.
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -443,7 +475,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -467,6 +502,7 @@ For example this:
 package main
 
 import (
+  "log"
   "os"
   "sort"
 
@@ -510,7 +546,10 @@ func main() {
   sort.Sort(cli.FlagsByName(app.Flags))
   sort.Sort(cli.CommandsByName(app.Commands))
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -533,6 +572,7 @@ You can also have the default value set from the environment via `EnvVar`.  e.g.
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -550,7 +590,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -565,6 +608,7 @@ environment variable that resolves is used as the default.
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -582,9 +626,51 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
+
+#### Values from files
+
+You can also have the default value set from file via `FilePath`.  e.g.
+
+<!-- {
+  "args": ["&#45;&#45;help"],
+  "output": "password for the mysql database"
+} -->
+``` go
+package main
+
+import (
+  "log"
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  app := cli.NewApp()
+
+  app.Flags = []cli.Flag {
+    cli.StringFlag{
+      Name: "password, p",
+      Usage: "password for the mysql database",
+      FilePath: "/etc/mysql/password",
+    },
+  }
+
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
+}
+```
+
+Note that default values set from file (e.g. `FilePath`) take precedence over
+default values set from the environment (e.g. `EnvVar`).
 
 #### Values from alternate input sources (YAML, TOML, and others)
 
@@ -615,9 +701,9 @@ the yaml input source for any flags that are defined on that command.  As a note
 the "load" flag used would also have to be defined on the command flags in order
 for this code snipped to work.
 
-Currently only the aboved specified formats are supported but developers can
-add support for other input sources by implementing the
-altsrc.InputSourceContext for their given sources.
+Currently only YAML and JSON files are supported but developers can add support
+for other input sources by implementing the altsrc.InputSourceContext for their
+given sources.
 
 Here is a more complete sample of a command using YAML support:
 
@@ -630,6 +716,7 @@ package notmain
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -652,9 +739,21 @@ func main() {
   app.Before = altsrc.InitInputSourceWithContext(flags, altsrc.NewYamlSourceFromFlagFunc("load"))
   app.Flags = flags
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
+
+#### Precedence
+
+The precedence for flag value sources is as follows (highest to lowest):
+
+0. Command line flag value from user
+0. Environment variable (if specified)
+0. Configuration file (if specified)
+0. Default defined on the flag
 
 ### Subcommands
 
@@ -669,6 +768,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -721,7 +821,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -737,6 +840,7 @@ E.g.
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -751,15 +855,18 @@ func main() {
     },
     {
       Name:     "add",
-      Category: "template",
+      Category: "Template actions",
     },
     {
       Name:     "remove",
-      Category: "template",
+      Category: "Template actions",
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -767,7 +874,7 @@ Will include:
 
 ```
 COMMANDS:
-    noop
+  noop
 
   Template actions:
     add
@@ -785,6 +892,7 @@ may be set by returning a non-nil error that fulfills `cli.ExitCoder`, *or* a
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -805,7 +913,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -825,6 +936,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -856,7 +968,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -896,6 +1011,7 @@ The default bash completion flag (`--generate-bash-completion`) is defined as
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -914,7 +1030,10 @@ func main() {
       Name: "wat",
     },
   }
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -940,6 +1059,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "io"
   "os"
 
@@ -983,7 +1103,10 @@ VERSION:
     fmt.Println("Ha HA.  I pwnd the help!!1")
   }
 
-  cli.NewApp().Run(os.Args)
+  err := cli.NewApp().Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -998,6 +1121,7 @@ setting `cli.HelpFlag`, e.g.:
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -1010,7 +1134,10 @@ func main() {
     EnvVar: "SHOW_HALP,HALPPLZ",
   }
 
-  cli.NewApp().Run(os.Args)
+  err := cli.NewApp().Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -1033,6 +1160,7 @@ setting `cli.VersionFlag`, e.g.:
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -1047,7 +1175,10 @@ func main() {
   app := cli.NewApp()
   app.Name = "partay"
   app.Version = "19.99.0"
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -1062,6 +1193,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -1079,7 +1211,10 @@ func main() {
   app := cli.NewApp()
   app.Name = "partay"
   app.Version = "19.99.0"
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -1341,7 +1476,7 @@ func main() {
     ec := cli.NewExitError("ohwell", 86)
     fmt.Fprintf(c.App.Writer, "%d", ec.ExitCode())
     fmt.Printf("made it!\n")
-    return ec
+    return nil
   }
 
   if os.Getenv("HEXY") != "" {
@@ -1355,7 +1490,9 @@ func main() {
     "whatever-values": 19.99,
   }
 
-  app.Run(os.Args)
+
+  // ignore error so we don't exit non-zero and break gfmrun README example tests
+  _ = app.Run(os.Args)
 }
 
 func wopAction(c *cli.Context) error {
@@ -1364,18 +1501,26 @@ func wopAction(c *cli.Context) error {
 }
 ```
 
+### Combining short Bool options
+
+Traditional use of boolean options using their shortnames look like this:
+```
+# cmd foobar -s -o
+```
+
+Suppose you want users to be able to combine your bool options with their shortname.  This
+can be done using the **UseShortOptionHandling** bool in your commands.  Suppose your program
+has a two bool flags such as *serve* and *option* with the short options of *-o* and
+*-s* respectively. With **UseShortOptionHandling** set to *true*, a user can use a syntax
+like:
+```
+# cmd foobar -so
+```
+
+If you enable the **UseShortOptionHandling*, then you must not use any flags that have a single
+leading *-* or this will result in failures.  For example, **-option** can no longer be used.  Flags
+with two leading dashes (such as **--options**) are still valid.
+
 ## Contribution Guidelines
 
-Feel free to put up a pull request to fix a bug or maybe add a feature. I will
-give it a code review and make sure that it does not break backwards
-compatibility. If I or any other collaborators agree that it is in line with
-the vision of the project, we will work with you to get the code into
-a mergeable state and merge it into the master branch.
-
-If you have contributed something significant to the project, we will most
-likely add you as a collaborator. As a collaborator you are given the ability
-to merge others pull requests. It is very important that new code does not
-break existing code, so be careful about what code you do choose to merge.
-
-If you feel like you have contributed to the project but have not yet been
-added as a collaborator, we probably forgot to add you, please open an issue.
+See [./CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/vendor/github.com/urfave/cli/category.go
+++ b/vendor/github.com/urfave/cli/category.go
@@ -10,7 +10,7 @@ type CommandCategory struct {
 }
 
 func (c CommandCategories) Less(i, j int) bool {
-	return c[i].Name < c[j].Name
+	return lexicographicLess(c[i].Name, c[j].Name)
 }
 
 func (c CommandCategories) Len() int {

--- a/vendor/github.com/urfave/cli/command.go
+++ b/vendor/github.com/urfave/cli/command.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"sort"
@@ -55,6 +56,10 @@ type Command struct {
 	HideHelp bool
 	// Boolean to hide this command from help or completion
 	Hidden bool
+	// Boolean to enable short-option handling so user can combine several
+	// single-character bool arguments into one
+	// i.e. foobar -o -v -> foobar -ov
+	UseShortOptionHandling bool
 
 	// Full name of command for help, defaults to full command name, including parent commands.
 	HelpName        string
@@ -73,7 +78,7 @@ func (c CommandsByName) Len() int {
 }
 
 func (c CommandsByName) Less(i, j int) bool {
-	return c[i].Name < c[j].Name
+	return lexicographicLess(c[i].Name, c[j].Name)
 }
 
 func (c CommandsByName) Swap(i, j int) {
@@ -106,57 +111,7 @@ func (c Command) Run(ctx *Context) (err error) {
 		)
 	}
 
-	set, err := flagSet(c.Name, c.Flags)
-	if err != nil {
-		return err
-	}
-	set.SetOutput(ioutil.Discard)
-
-	if c.SkipFlagParsing {
-		err = set.Parse(append([]string{"--"}, ctx.Args().Tail()...))
-	} else if !c.SkipArgReorder {
-		firstFlagIndex := -1
-		terminatorIndex := -1
-		for index, arg := range ctx.Args() {
-			if arg == "--" {
-				terminatorIndex = index
-				break
-			} else if arg == "-" {
-				// Do nothing. A dash alone is not really a flag.
-				continue
-			} else if strings.HasPrefix(arg, "-") && firstFlagIndex == -1 {
-				firstFlagIndex = index
-			}
-		}
-
-		if firstFlagIndex > -1 {
-			args := ctx.Args()
-			regularArgs := make([]string, len(args[1:firstFlagIndex]))
-			copy(regularArgs, args[1:firstFlagIndex])
-
-			var flagArgs []string
-			if terminatorIndex > -1 {
-				flagArgs = args[firstFlagIndex:terminatorIndex]
-				regularArgs = append(regularArgs, args[terminatorIndex:]...)
-			} else {
-				flagArgs = args[firstFlagIndex:]
-			}
-
-			err = set.Parse(append(flagArgs, regularArgs...))
-		} else {
-			err = set.Parse(ctx.Args().Tail())
-		}
-	} else {
-		err = set.Parse(ctx.Args().Tail())
-	}
-
-	nerr := normalizeFlags(c.Flags, set)
-	if nerr != nil {
-		fmt.Fprintln(ctx.App.Writer, nerr)
-		fmt.Fprintln(ctx.App.Writer)
-		ShowCommandHelp(ctx, c.Name)
-		return nerr
-	}
+	set, err := c.parseFlags(ctx.Args().Tail())
 
 	context := NewContext(ctx.App, set, ctx)
 	context.Command = c
@@ -167,7 +122,7 @@ func (c Command) Run(ctx *Context) (err error) {
 	if err != nil {
 		if c.OnUsageError != nil {
 			err := c.OnUsageError(context, err, false)
-			HandleExitCoder(err)
+			context.App.handleExitCoder(context, err)
 			return err
 		}
 		fmt.Fprintln(context.App.Writer, "Incorrect Usage:", err.Error())
@@ -180,11 +135,17 @@ func (c Command) Run(ctx *Context) (err error) {
 		return nil
 	}
 
+	cerr := checkRequiredFlags(c.Flags, context)
+	if cerr != nil {
+		ShowCommandHelp(context, c.Name)
+		return cerr
+	}
+
 	if c.After != nil {
 		defer func() {
 			afterErr := c.After(context)
 			if afterErr != nil {
-				HandleExitCoder(err)
+				context.App.handleExitCoder(context, err)
 				if err != nil {
 					err = NewMultiError(err, afterErr)
 				} else {
@@ -198,7 +159,7 @@ func (c Command) Run(ctx *Context) (err error) {
 		err = c.Before(context)
 		if err != nil {
 			ShowCommandHelp(context, c.Name)
-			HandleExitCoder(err)
+			context.App.handleExitCoder(context, err)
 			return err
 		}
 	}
@@ -210,9 +171,133 @@ func (c Command) Run(ctx *Context) (err error) {
 	err = HandleAction(c.Action, context)
 
 	if err != nil {
-		HandleExitCoder(err)
+		context.App.handleExitCoder(context, err)
 	}
 	return err
+}
+
+func (c *Command) parseFlags(args Args) (*flag.FlagSet, error) {
+	set, err := flagSet(c.Name, c.Flags)
+	if err != nil {
+		return nil, err
+	}
+	set.SetOutput(ioutil.Discard)
+
+	if c.SkipFlagParsing {
+		return set, set.Parse(append([]string{"--"}, args...))
+	}
+
+	if !c.SkipArgReorder {
+		args = reorderArgs(args)
+	}
+
+PARSE:
+	err = set.Parse(args)
+	if err != nil {
+		if c.UseShortOptionHandling {
+			// To enable short-option handling (e.g., "-it" vs "-i -t")
+			// we have to iteratively catch parsing errors.  This way
+			// we achieve LR parsing without transforming any arguments.
+			// Otherwise, there is no way we can discriminate combined
+			// short options from common arguments that should be left
+			// untouched.
+			errStr := err.Error()
+			trimmed := strings.TrimPrefix(errStr, "flag provided but not defined: ")
+			if errStr == trimmed {
+				return nil, err
+			}
+			// regenerate the initial args with the split short opts
+			newArgs := Args{}
+			for i, arg := range args {
+				if arg != trimmed {
+					newArgs = append(newArgs, arg)
+					continue
+				}
+				shortOpts := translateShortOptions(set, Args{trimmed})
+				if len(shortOpts) == 1 {
+					return nil, err
+				}
+				// add each short option and all remaining arguments
+				newArgs = append(newArgs, shortOpts...)
+				newArgs = append(newArgs, args[i+1:]...)
+				args = newArgs
+				// now reset the flagset parse again
+				set, err = flagSet(c.Name, c.Flags)
+				if err != nil {
+					return nil, err
+				}
+				set.SetOutput(ioutil.Discard)
+				goto PARSE
+			}
+		}
+		return nil, err
+	}
+
+	err = normalizeFlags(c.Flags, set)
+	if err != nil {
+		return nil, err
+	}
+
+	return set, nil
+}
+
+// reorderArgs moves all flags before arguments as this is what flag expects
+func reorderArgs(args []string) []string {
+	var nonflags, flags []string
+
+	readFlagValue := false
+	for i, arg := range args {
+		if arg == "--" {
+			nonflags = append(nonflags, args[i:]...)
+			break
+		}
+
+		if readFlagValue && !strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") {
+			readFlagValue = false
+			flags = append(flags, arg)
+			continue
+		}
+		readFlagValue = false
+
+		if arg != "-" && strings.HasPrefix(arg, "-") {
+			flags = append(flags, arg)
+
+			readFlagValue = !strings.Contains(arg, "=")
+		} else {
+			nonflags = append(nonflags, arg)
+		}
+	}
+
+	return append(flags, nonflags...)
+}
+
+func translateShortOptions(set *flag.FlagSet, flagArgs Args) []string {
+	allCharsFlags := func (s string) bool {
+		for i := range s {
+			f := set.Lookup(string(s[i]))
+			if f == nil {
+				return false
+			}
+		}
+		return true
+	}
+
+	// separate combined flags
+	var flagArgsSeparated []string
+	for _, flagArg := range flagArgs {
+		if strings.HasPrefix(flagArg, "-") && strings.HasPrefix(flagArg, "--") == false && len(flagArg) > 2 {
+			if !allCharsFlags(flagArg[1:]) {
+				flagArgsSeparated = append(flagArgsSeparated, flagArg)
+				continue
+			}
+			for _, flagChar := range flagArg[1:] {
+				flagArgsSeparated = append(flagArgsSeparated, "-"+string(flagChar))
+			}
+		} else {
+			flagArgsSeparated = append(flagArgsSeparated, flagArg)
+		}
+	}
+	return flagArgsSeparated
 }
 
 // Names returns the names including short names and aliases.

--- a/vendor/github.com/urfave/cli/context.go
+++ b/vendor/github.com/urfave/cli/context.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"errors"
 	"flag"
+	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"syscall"
@@ -73,7 +75,7 @@ func (c *Context) IsSet(name string) bool {
 		// change in version 2 to add `IsSet` to the Flag interface to push the
 		// responsibility closer to where the information required to determine
 		// whether a flag is set by non-standard means such as environment
-		// variables is avaliable.
+		// variables is available.
 		//
 		// See https://github.com/urfave/cli/issues/294 for additional discussion
 		flags := c.Command.Flags
@@ -93,18 +95,26 @@ func (c *Context) IsSet(name string) bool {
 					val = val.Elem()
 				}
 
-				envVarValue := val.FieldByName("EnvVar")
-				if !envVarValue.IsValid() {
-					return
+				filePathValue := val.FieldByName("FilePath")
+				if filePathValue.IsValid() {
+					eachName(filePathValue.String(), func(filePath string) {
+						if _, err := os.Stat(filePath); err == nil {
+							c.setFlags[name] = true
+							return
+						}
+					})
 				}
 
-				eachName(envVarValue.String(), func(envVar string) {
-					envVar = strings.TrimSpace(envVar)
-					if _, ok := syscall.Getenv(envVar); ok {
-						c.setFlags[name] = true
-						return
-					}
-				})
+				envVarValue := val.FieldByName("EnvVar")
+				if envVarValue.IsValid() {
+					eachName(envVarValue.String(), func(envVar string) {
+						envVar = strings.TrimSpace(envVar)
+						if _, ok := syscall.Getenv(envVar); ok {
+							c.setFlags[name] = true
+							return
+						}
+					})
+				}
 			})
 		}
 	}
@@ -274,5 +284,45 @@ func normalizeFlags(flags []Flag, set *flag.FlagSet) error {
 			}
 		}
 	}
+	return nil
+}
+
+type requiredFlagsErr interface {
+	error
+	getMissingFlags() []string
+}
+
+type errRequiredFlags struct {
+	missingFlags []string
+}
+
+func (e *errRequiredFlags) Error() string {
+	numberOfMissingFlags := len(e.missingFlags)
+	if numberOfMissingFlags == 1 {
+		return fmt.Sprintf("Required flag %q not set", e.missingFlags[0])
+	}
+	joinedMissingFlags := strings.Join(e.missingFlags, ", ")
+	return fmt.Sprintf("Required flags %q not set", joinedMissingFlags)
+}
+
+func (e *errRequiredFlags) getMissingFlags() []string {
+	return e.missingFlags
+}
+
+func checkRequiredFlags(flags []Flag, context *Context) requiredFlagsErr {
+	var missingFlags []string
+	for _, f := range flags {
+		if rf, ok := f.(RequiredFlag); ok && rf.IsRequired() {
+			key := strings.Split(f.GetName(), ",")[0]
+			if !context.IsSet(key) {
+				missingFlags = append(missingFlags, key)
+			}
+		}
+	}
+
+	if len(missingFlags) != 0 {
+		return &errRequiredFlags{missingFlags: missingFlags}
+	}
+
 	return nil
 }

--- a/vendor/github.com/urfave/cli/flag.go
+++ b/vendor/github.com/urfave/cli/flag.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"reflect"
 	"runtime"
 	"strconv"
@@ -37,6 +38,18 @@ var HelpFlag Flag = BoolFlag{
 // to display a flag.
 var FlagStringer FlagStringFunc = stringifyFlag
 
+// FlagNamePrefixer converts a full flag name and its placeholder into the help
+// message flag prefix. This is used by the default FlagStringer.
+var FlagNamePrefixer FlagNamePrefixFunc = prefixedNames
+
+// FlagEnvHinter annotates flag help message with the environment variable
+// details. This is used by the default FlagStringer.
+var FlagEnvHinter FlagEnvHintFunc = withEnvHint
+
+// FlagFileHinter annotates flag help message with the environment variable
+// details. This is used by the default FlagStringer.
+var FlagFileHinter FlagFileHintFunc = withFileHint
+
 // FlagsByName is a slice of Flag.
 type FlagsByName []Flag
 
@@ -45,7 +58,7 @@ func (f FlagsByName) Len() int {
 }
 
 func (f FlagsByName) Less(i, j int) bool {
-	return f[i].GetName() < f[j].GetName()
+	return lexicographicLess(f[i].GetName(), f[j].GetName())
 }
 
 func (f FlagsByName) Swap(i, j int) {
@@ -60,6 +73,14 @@ type Flag interface {
 	// Apply Flag settings to the given flag set
 	Apply(*flag.FlagSet)
 	GetName() string
+}
+
+// RequiredFlag is an interface that allows us to mark flags as required
+// it allows flags required flags to be backwards compatible with the Flag interface
+type RequiredFlag interface {
+	Flag
+
+	IsRequired() bool
 }
 
 // errorableFlag is an interface that allows us to return errors during apply
@@ -112,15 +133,9 @@ func (f GenericFlag) Apply(set *flag.FlagSet) {
 // provided by the user for parsing by the flag
 func (f GenericFlag) ApplyWithError(set *flag.FlagSet) error {
 	val := f.Value
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				if err := val.Set(envVal); err != nil {
-					return fmt.Errorf("could not parse %s as value for flag %s: %s", envVal, f.Name, err)
-				}
-				break
-			}
+	if fileEnvVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		if err := val.Set(fileEnvVal); err != nil {
+			return fmt.Errorf("could not parse %s as value for flag %s: %s", fileEnvVal, f.Name, err)
 		}
 	}
 
@@ -163,20 +178,18 @@ func (f StringSliceFlag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f StringSliceFlag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				newVal := &StringSlice{}
-				for _, s := range strings.Split(envVal, ",") {
-					s = strings.TrimSpace(s)
-					if err := newVal.Set(s); err != nil {
-						return fmt.Errorf("could not parse %s as string value for flag %s: %s", envVal, f.Name, err)
-					}
-				}
-				f.Value = newVal
-				break
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		newVal := &StringSlice{}
+		for _, s := range strings.Split(envVal, ",") {
+			s = strings.TrimSpace(s)
+			if err := newVal.Set(s); err != nil {
+				return fmt.Errorf("could not parse %s as string value for flag %s: %s", envVal, f.Name, err)
 			}
+		}
+		if f.Value == nil {
+			f.Value = newVal
+		} else {
+			*f.Value = *newVal
 		}
 	}
 
@@ -226,20 +239,18 @@ func (f IntSliceFlag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f IntSliceFlag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				newVal := &IntSlice{}
-				for _, s := range strings.Split(envVal, ",") {
-					s = strings.TrimSpace(s)
-					if err := newVal.Set(s); err != nil {
-						return fmt.Errorf("could not parse %s as int slice value for flag %s: %s", envVal, f.Name, err)
-					}
-				}
-				f.Value = newVal
-				break
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		newVal := &IntSlice{}
+		for _, s := range strings.Split(envVal, ",") {
+			s = strings.TrimSpace(s)
+			if err := newVal.Set(s); err != nil {
+				return fmt.Errorf("could not parse %s as int slice value for flag %s: %s", envVal, f.Name, err)
 			}
+		}
+		if f.Value == nil {
+			f.Value = newVal
+		} else {
+			*f.Value = *newVal
 		}
 	}
 
@@ -289,20 +300,18 @@ func (f Int64SliceFlag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f Int64SliceFlag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				newVal := &Int64Slice{}
-				for _, s := range strings.Split(envVal, ",") {
-					s = strings.TrimSpace(s)
-					if err := newVal.Set(s); err != nil {
-						return fmt.Errorf("could not parse %s as int64 slice value for flag %s: %s", envVal, f.Name, err)
-					}
-				}
-				f.Value = newVal
-				break
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		newVal := &Int64Slice{}
+		for _, s := range strings.Split(envVal, ",") {
+			s = strings.TrimSpace(s)
+			if err := newVal.Set(s); err != nil {
+				return fmt.Errorf("could not parse %s as int64 slice value for flag %s: %s", envVal, f.Name, err)
 			}
+		}
+		if f.Value == nil {
+			f.Value = newVal
+		} else {
+			*f.Value = *newVal
 		}
 	}
 
@@ -324,23 +333,15 @@ func (f BoolFlag) Apply(set *flag.FlagSet) {
 // ApplyWithError populates the flag given the flag set and environment
 func (f BoolFlag) ApplyWithError(set *flag.FlagSet) error {
 	val := false
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				if envVal == "" {
-					val = false
-					break
-				}
-
-				envValBool, err := strconv.ParseBool(envVal)
-				if err != nil {
-					return fmt.Errorf("could not parse %s as bool value for flag %s: %s", envVal, f.Name, err)
-				}
-
-				val = envValBool
-				break
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		if envVal == "" {
+			val = false
+		} else {
+			envValBool, err := strconv.ParseBool(envVal)
+			if err != nil {
+				return fmt.Errorf("could not parse %s as bool value for flag %s: %s", envVal, f.Name, err)
 			}
+			val = envValBool
 		}
 	}
 
@@ -364,23 +365,16 @@ func (f BoolTFlag) Apply(set *flag.FlagSet) {
 // ApplyWithError populates the flag given the flag set and environment
 func (f BoolTFlag) ApplyWithError(set *flag.FlagSet) error {
 	val := true
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				if envVal == "" {
-					val = false
-					break
-				}
 
-				envValBool, err := strconv.ParseBool(envVal)
-				if err != nil {
-					return fmt.Errorf("could not parse %s as bool value for flag %s: %s", envVal, f.Name, err)
-				}
-
-				val = envValBool
-				break
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		if envVal == "" {
+			val = false
+		} else {
+			envValBool, err := strconv.ParseBool(envVal)
+			if err != nil {
+				return fmt.Errorf("could not parse %s as bool value for flag %s: %s", envVal, f.Name, err)
 			}
+			val = envValBool
 		}
 	}
 
@@ -403,14 +397,8 @@ func (f StringFlag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f StringFlag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				f.Value = envVal
-				break
-			}
-		}
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		f.Value = envVal
 	}
 
 	eachName(f.Name, func(name string) {
@@ -432,18 +420,12 @@ func (f IntFlag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f IntFlag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				envValInt, err := strconv.ParseInt(envVal, 0, 64)
-				if err != nil {
-					return fmt.Errorf("could not parse %s as int value for flag %s: %s", envVal, f.Name, err)
-				}
-				f.Value = int(envValInt)
-				break
-			}
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValInt, err := strconv.ParseInt(envVal, 0, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as int value for flag %s: %s", envVal, f.Name, err)
 		}
+		f.Value = int(envValInt)
 	}
 
 	eachName(f.Name, func(name string) {
@@ -465,19 +447,13 @@ func (f Int64Flag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f Int64Flag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				envValInt, err := strconv.ParseInt(envVal, 0, 64)
-				if err != nil {
-					return fmt.Errorf("could not parse %s as int value for flag %s: %s", envVal, f.Name, err)
-				}
-
-				f.Value = envValInt
-				break
-			}
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValInt, err := strconv.ParseInt(envVal, 0, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as int value for flag %s: %s", envVal, f.Name, err)
 		}
+
+		f.Value = envValInt
 	}
 
 	eachName(f.Name, func(name string) {
@@ -499,19 +475,13 @@ func (f UintFlag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f UintFlag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				envValInt, err := strconv.ParseUint(envVal, 0, 64)
-				if err != nil {
-					return fmt.Errorf("could not parse %s as uint value for flag %s: %s", envVal, f.Name, err)
-				}
-
-				f.Value = uint(envValInt)
-				break
-			}
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValInt, err := strconv.ParseUint(envVal, 0, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as uint value for flag %s: %s", envVal, f.Name, err)
 		}
+
+		f.Value = uint(envValInt)
 	}
 
 	eachName(f.Name, func(name string) {
@@ -533,19 +503,13 @@ func (f Uint64Flag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f Uint64Flag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				envValInt, err := strconv.ParseUint(envVal, 0, 64)
-				if err != nil {
-					return fmt.Errorf("could not parse %s as uint64 value for flag %s: %s", envVal, f.Name, err)
-				}
-
-				f.Value = uint64(envValInt)
-				break
-			}
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValInt, err := strconv.ParseUint(envVal, 0, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as uint64 value for flag %s: %s", envVal, f.Name, err)
 		}
+
+		f.Value = uint64(envValInt)
 	}
 
 	eachName(f.Name, func(name string) {
@@ -567,19 +531,13 @@ func (f DurationFlag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f DurationFlag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				envValDuration, err := time.ParseDuration(envVal)
-				if err != nil {
-					return fmt.Errorf("could not parse %s as duration for flag %s: %s", envVal, f.Name, err)
-				}
-
-				f.Value = envValDuration
-				break
-			}
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValDuration, err := time.ParseDuration(envVal)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as duration for flag %s: %s", envVal, f.Name, err)
 		}
+
+		f.Value = envValDuration
 	}
 
 	eachName(f.Name, func(name string) {
@@ -601,19 +559,13 @@ func (f Float64Flag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f Float64Flag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				envValFloat, err := strconv.ParseFloat(envVal, 10)
-				if err != nil {
-					return fmt.Errorf("could not parse %s as float64 value for flag %s: %s", envVal, f.Name, err)
-				}
-
-				f.Value = float64(envValFloat)
-				break
-			}
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValFloat, err := strconv.ParseFloat(envVal, 10)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as float64 value for flag %s: %s", envVal, f.Name, err)
 		}
+
+		f.Value = float64(envValFloat)
 	}
 
 	eachName(f.Name, func(name string) {
@@ -692,9 +644,17 @@ func withEnvHint(envVar, str string) string {
 			suffix = "%"
 			sep = "%, %"
 		}
-		envText = fmt.Sprintf(" [%s%s%s]", prefix, strings.Join(strings.Split(envVar, ","), sep), suffix)
+		envText = " [" + prefix + strings.Join(strings.Split(envVar, ","), sep) + suffix + "]"
 	}
 	return str + envText
+}
+
+func withFileHint(filePath, str string) string {
+	fileText := ""
+	if filePath != "" {
+		fileText = fmt.Sprintf(" [%s]", filePath)
+	}
+	return str + fileText
 }
 
 func flagValue(f Flag) reflect.Value {
@@ -710,14 +670,29 @@ func stringifyFlag(f Flag) string {
 
 	switch f.(type) {
 	case IntSliceFlag:
-		return withEnvHint(fv.FieldByName("EnvVar").String(),
-			stringifyIntSliceFlag(f.(IntSliceFlag)))
+		return FlagFileHinter(
+			fv.FieldByName("FilePath").String(),
+			FlagEnvHinter(
+				fv.FieldByName("EnvVar").String(),
+				stringifyIntSliceFlag(f.(IntSliceFlag)),
+			),
+		)
 	case Int64SliceFlag:
-		return withEnvHint(fv.FieldByName("EnvVar").String(),
-			stringifyInt64SliceFlag(f.(Int64SliceFlag)))
+		return FlagFileHinter(
+			fv.FieldByName("FilePath").String(),
+			FlagEnvHinter(
+				fv.FieldByName("EnvVar").String(),
+				stringifyInt64SliceFlag(f.(Int64SliceFlag)),
+			),
+		)
 	case StringSliceFlag:
-		return withEnvHint(fv.FieldByName("EnvVar").String(),
-			stringifyStringSliceFlag(f.(StringSliceFlag)))
+		return FlagFileHinter(
+			fv.FieldByName("FilePath").String(),
+			FlagEnvHinter(
+				fv.FieldByName("EnvVar").String(),
+				stringifyStringSliceFlag(f.(StringSliceFlag)),
+			),
+		)
 	}
 
 	placeholder, usage := unquoteUsage(fv.FieldByName("Usage").String())
@@ -742,17 +717,22 @@ func stringifyFlag(f Flag) string {
 		placeholder = defaultPlaceholder
 	}
 
-	usageWithDefault := strings.TrimSpace(fmt.Sprintf("%s%s", usage, defaultValueString))
+	usageWithDefault := strings.TrimSpace(usage + defaultValueString)
 
-	return withEnvHint(fv.FieldByName("EnvVar").String(),
-		fmt.Sprintf("%s\t%s", prefixedNames(fv.FieldByName("Name").String(), placeholder), usageWithDefault))
+	return FlagFileHinter(
+		fv.FieldByName("FilePath").String(),
+		FlagEnvHinter(
+			fv.FieldByName("EnvVar").String(),
+			FlagNamePrefixer(fv.FieldByName("Name").String(), placeholder)+"\t"+usageWithDefault,
+		),
+	)
 }
 
 func stringifyIntSliceFlag(f IntSliceFlag) string {
 	defaultVals := []string{}
 	if f.Value != nil && len(f.Value.Value()) > 0 {
 		for _, i := range f.Value.Value() {
-			defaultVals = append(defaultVals, fmt.Sprintf("%d", i))
+			defaultVals = append(defaultVals, strconv.Itoa(i))
 		}
 	}
 
@@ -763,7 +743,7 @@ func stringifyInt64SliceFlag(f Int64SliceFlag) string {
 	defaultVals := []string{}
 	if f.Value != nil && len(f.Value.Value()) > 0 {
 		for _, i := range f.Value.Value() {
-			defaultVals = append(defaultVals, fmt.Sprintf("%d", i))
+			defaultVals = append(defaultVals, strconv.FormatInt(i, 10))
 		}
 	}
 
@@ -775,7 +755,7 @@ func stringifyStringSliceFlag(f StringSliceFlag) string {
 	if f.Value != nil && len(f.Value.Value()) > 0 {
 		for _, s := range f.Value.Value() {
 			if len(s) > 0 {
-				defaultVals = append(defaultVals, fmt.Sprintf("%q", s))
+				defaultVals = append(defaultVals, strconv.Quote(s))
 			}
 		}
 	}
@@ -794,6 +774,21 @@ func stringifySliceFlag(usage, name string, defaultVals []string) string {
 		defaultVal = fmt.Sprintf(" (default: %s)", strings.Join(defaultVals, ", "))
 	}
 
-	usageWithDefault := strings.TrimSpace(fmt.Sprintf("%s%s", usage, defaultVal))
-	return fmt.Sprintf("%s\t%s", prefixedNames(name, placeholder), usageWithDefault)
+	usageWithDefault := strings.TrimSpace(usage + defaultVal)
+	return FlagNamePrefixer(name, placeholder) + "\t" + usageWithDefault
+}
+
+func flagFromFileEnv(filePath, envName string) (val string, ok bool) {
+	for _, envVar := range strings.Split(envName, ",") {
+		envVar = strings.TrimSpace(envVar)
+		if envVal, ok := syscall.Getenv(envVar); ok {
+			return envVal, true
+		}
+	}
+	for _, fileVar := range strings.Split(filePath, ",") {
+		if data, err := ioutil.ReadFile(fileVar); err == nil {
+			return string(data), true
+		}
+	}
+	return "", false
 }

--- a/vendor/github.com/urfave/cli/flag_generated.go
+++ b/vendor/github.com/urfave/cli/flag_generated.go
@@ -13,6 +13,8 @@ type BoolFlag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
+	Required    bool
 	Hidden      bool
 	Destination *bool
 }
@@ -26,6 +28,11 @@ func (f BoolFlag) String() string {
 // GetName returns the name of the flag
 func (f BoolFlag) GetName() string {
 	return f.Name
+}
+
+// IsRequired returns the whether or not the flag is required
+func (f BoolFlag) IsRequired() bool {
+	return f.Required
 }
 
 // Bool looks up the value of a local BoolFlag, returns
@@ -60,6 +67,8 @@ type BoolTFlag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
+	Required    bool
 	Hidden      bool
 	Destination *bool
 }
@@ -73,6 +82,11 @@ func (f BoolTFlag) String() string {
 // GetName returns the name of the flag
 func (f BoolTFlag) GetName() string {
 	return f.Name
+}
+
+// IsRequired returns the whether or not the flag is required
+func (f BoolTFlag) IsRequired() bool {
+	return f.Required
 }
 
 // BoolT looks up the value of a local BoolTFlag, returns
@@ -107,6 +121,8 @@ type DurationFlag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
+	Required    bool
 	Hidden      bool
 	Value       time.Duration
 	Destination *time.Duration
@@ -121,6 +137,11 @@ func (f DurationFlag) String() string {
 // GetName returns the name of the flag
 func (f DurationFlag) GetName() string {
 	return f.Name
+}
+
+// IsRequired returns the whether or not the flag is required
+func (f DurationFlag) IsRequired() bool {
+	return f.Required
 }
 
 // Duration looks up the value of a local DurationFlag, returns
@@ -155,6 +176,8 @@ type Float64Flag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
+	Required    bool
 	Hidden      bool
 	Value       float64
 	Destination *float64
@@ -169,6 +192,11 @@ func (f Float64Flag) String() string {
 // GetName returns the name of the flag
 func (f Float64Flag) GetName() string {
 	return f.Name
+}
+
+// IsRequired returns the whether or not the flag is required
+func (f Float64Flag) IsRequired() bool {
+	return f.Required
 }
 
 // Float64 looks up the value of a local Float64Flag, returns
@@ -200,11 +228,13 @@ func lookupFloat64(name string, set *flag.FlagSet) float64 {
 
 // GenericFlag is a flag with type Generic
 type GenericFlag struct {
-	Name   string
-	Usage  string
-	EnvVar string
-	Hidden bool
-	Value  Generic
+	Name     string
+	Usage    string
+	EnvVar   string
+	FilePath string
+	Required bool
+	Hidden   bool
+	Value    Generic
 }
 
 // String returns a readable representation of this value
@@ -216,6 +246,11 @@ func (f GenericFlag) String() string {
 // GetName returns the name of the flag
 func (f GenericFlag) GetName() string {
 	return f.Name
+}
+
+// IsRequired returns the whether or not the flag is required
+func (f GenericFlag) IsRequired() bool {
+	return f.Required
 }
 
 // Generic looks up the value of a local GenericFlag, returns
@@ -250,6 +285,8 @@ type Int64Flag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
+	Required    bool
 	Hidden      bool
 	Value       int64
 	Destination *int64
@@ -264,6 +301,11 @@ func (f Int64Flag) String() string {
 // GetName returns the name of the flag
 func (f Int64Flag) GetName() string {
 	return f.Name
+}
+
+// IsRequired returns the whether or not the flag is required
+func (f Int64Flag) IsRequired() bool {
+	return f.Required
 }
 
 // Int64 looks up the value of a local Int64Flag, returns
@@ -298,6 +340,8 @@ type IntFlag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
+	Required    bool
 	Hidden      bool
 	Value       int
 	Destination *int
@@ -312,6 +356,11 @@ func (f IntFlag) String() string {
 // GetName returns the name of the flag
 func (f IntFlag) GetName() string {
 	return f.Name
+}
+
+// IsRequired returns the whether or not the flag is required
+func (f IntFlag) IsRequired() bool {
+	return f.Required
 }
 
 // Int looks up the value of a local IntFlag, returns
@@ -343,11 +392,13 @@ func lookupInt(name string, set *flag.FlagSet) int {
 
 // IntSliceFlag is a flag with type *IntSlice
 type IntSliceFlag struct {
-	Name   string
-	Usage  string
-	EnvVar string
-	Hidden bool
-	Value  *IntSlice
+	Name     string
+	Usage    string
+	EnvVar   string
+	FilePath string
+	Required bool
+	Hidden   bool
+	Value    *IntSlice
 }
 
 // String returns a readable representation of this value
@@ -359,6 +410,11 @@ func (f IntSliceFlag) String() string {
 // GetName returns the name of the flag
 func (f IntSliceFlag) GetName() string {
 	return f.Name
+}
+
+// IsRequired returns the whether or not the flag is required
+func (f IntSliceFlag) IsRequired() bool {
+	return f.Required
 }
 
 // IntSlice looks up the value of a local IntSliceFlag, returns
@@ -390,11 +446,13 @@ func lookupIntSlice(name string, set *flag.FlagSet) []int {
 
 // Int64SliceFlag is a flag with type *Int64Slice
 type Int64SliceFlag struct {
-	Name   string
-	Usage  string
-	EnvVar string
-	Hidden bool
-	Value  *Int64Slice
+	Name     string
+	Usage    string
+	EnvVar   string
+	FilePath string
+	Required bool
+	Hidden   bool
+	Value    *Int64Slice
 }
 
 // String returns a readable representation of this value
@@ -406,6 +464,11 @@ func (f Int64SliceFlag) String() string {
 // GetName returns the name of the flag
 func (f Int64SliceFlag) GetName() string {
 	return f.Name
+}
+
+// IsRequired returns the whether or not the flag is required
+func (f Int64SliceFlag) IsRequired() bool {
+	return f.Required
 }
 
 // Int64Slice looks up the value of a local Int64SliceFlag, returns
@@ -440,6 +503,8 @@ type StringFlag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
+	Required    bool
 	Hidden      bool
 	Value       string
 	Destination *string
@@ -454,6 +519,11 @@ func (f StringFlag) String() string {
 // GetName returns the name of the flag
 func (f StringFlag) GetName() string {
 	return f.Name
+}
+
+// IsRequired returns the whether or not the flag is required
+func (f StringFlag) IsRequired() bool {
+	return f.Required
 }
 
 // String looks up the value of a local StringFlag, returns
@@ -485,11 +555,13 @@ func lookupString(name string, set *flag.FlagSet) string {
 
 // StringSliceFlag is a flag with type *StringSlice
 type StringSliceFlag struct {
-	Name   string
-	Usage  string
-	EnvVar string
-	Hidden bool
-	Value  *StringSlice
+	Name     string
+	Usage    string
+	EnvVar   string
+	FilePath string
+	Required bool
+	Hidden   bool
+	Value    *StringSlice
 }
 
 // String returns a readable representation of this value
@@ -501,6 +573,11 @@ func (f StringSliceFlag) String() string {
 // GetName returns the name of the flag
 func (f StringSliceFlag) GetName() string {
 	return f.Name
+}
+
+// IsRequired returns the whether or not the flag is required
+func (f StringSliceFlag) IsRequired() bool {
+	return f.Required
 }
 
 // StringSlice looks up the value of a local StringSliceFlag, returns
@@ -535,6 +612,8 @@ type Uint64Flag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
+	Required    bool
 	Hidden      bool
 	Value       uint64
 	Destination *uint64
@@ -549,6 +628,11 @@ func (f Uint64Flag) String() string {
 // GetName returns the name of the flag
 func (f Uint64Flag) GetName() string {
 	return f.Name
+}
+
+// IsRequired returns the whether or not the flag is required
+func (f Uint64Flag) IsRequired() bool {
+	return f.Required
 }
 
 // Uint64 looks up the value of a local Uint64Flag, returns
@@ -583,6 +667,8 @@ type UintFlag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
+	Required    bool
 	Hidden      bool
 	Value       uint
 	Destination *uint
@@ -597,6 +683,11 @@ func (f UintFlag) String() string {
 // GetName returns the name of the flag
 func (f UintFlag) GetName() string {
 	return f.Name
+}
+
+// IsRequired returns the whether or not the flag is required
+func (f UintFlag) IsRequired() bool {
+	return f.Required
 }
 
 // Uint looks up the value of a local UintFlag, returns

--- a/vendor/github.com/urfave/cli/funcs.go
+++ b/vendor/github.com/urfave/cli/funcs.go
@@ -23,6 +23,22 @@ type CommandNotFoundFunc func(*Context, string)
 // is displayed and the execution is interrupted.
 type OnUsageErrorFunc func(context *Context, err error, isSubcommand bool) error
 
+// ExitErrHandlerFunc is executed if provided in order to handle ExitError values
+// returned by Actions and Before/After functions.
+type ExitErrHandlerFunc func(context *Context, err error)
+
 // FlagStringFunc is used by the help generation to display a flag, which is
 // expected to be a single line.
 type FlagStringFunc func(Flag) string
+
+// FlagNamePrefixFunc is used by the default FlagStringFunc to create prefix
+// text for a flag's full name.
+type FlagNamePrefixFunc func(fullName, placeholder string) string
+
+// FlagEnvHintFunc is used by the default FlagStringFunc to annotate flag help
+// with the environment variable details.
+type FlagEnvHintFunc func(envVar, str string) string
+
+// FlagFileHintFunc is used by the default FlagStringFunc to annotate flag help
+// with the file path details.
+type FlagFileHintFunc func(filePath, str string) string

--- a/vendor/github.com/urfave/cli/generate-flag-types
+++ b/vendor/github.com/urfave/cli/generate-flag-types
@@ -142,6 +142,8 @@ def _write_cli_flag_types(outfile, types):
             Name string
             Usage string
             EnvVar string
+            FilePath string
+            Required bool
             Hidden bool
         """.format(**typedef))
 
@@ -167,6 +169,11 @@ def _write_cli_flag_types(outfile, types):
             // GetName returns the name of the flag
             func (f {name}Flag) GetName() string {{
                 return f.Name
+            }}
+
+            // IsRequired returns the whether or not the flag is required
+            func (f {name}Flag) IsRequired() bool {{
+                return f.Required
             }}
 
             // {name} looks up the value of a local {name}Flag, returns

--- a/vendor/github.com/urfave/cli/go.mod
+++ b/vendor/github.com/urfave/cli/go.mod
@@ -1,0 +1,8 @@
+module github.com/urfave/cli
+
+go 1.12
+
+require (
+	github.com/BurntSushi/toml v0.3.1
+	gopkg.in/yaml.v2 v2.2.2
+)

--- a/vendor/github.com/urfave/cli/go.sum
+++ b/vendor/github.com/urfave/cli/go.sum
@@ -1,0 +1,6 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/vendor/github.com/urfave/cli/help.go
+++ b/vendor/github.com/urfave/cli/help.go
@@ -29,8 +29,10 @@ AUTHOR{{with $length := len .Authors}}{{if ne 1 $length}}S{{end}}{{end}}:
    {{end}}{{$author}}{{end}}{{end}}{{if .VisibleCommands}}
 
 COMMANDS:{{range .VisibleCategories}}{{if .Name}}
-   {{.Name}}:{{end}}{{range .VisibleCommands}}
-     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+
+   {{.Name}}:{{range .VisibleCommands}}
+     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{else}}{{range .VisibleCommands}}
+   {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
 
 GLOBAL OPTIONS:
    {{range $index, $option := .VisibleFlags}}{{if $index}}
@@ -70,9 +72,11 @@ USAGE:
    {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} command{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}
 
 COMMANDS:{{range .VisibleCategories}}{{if .Name}}
-   {{.Name}}:{{end}}{{range .VisibleCommands}}
-     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}
-{{end}}{{if .VisibleFlags}}
+
+   {{.Name}}:{{range .VisibleCommands}}
+     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{else}}{{range .VisibleCommands}}
+   {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+
 OPTIONS:
    {{range .VisibleFlags}}{{.}}
    {{end}}{{end}}
@@ -157,8 +161,14 @@ func DefaultAppComplete(c *Context) {
 		if command.Hidden {
 			continue
 		}
-		for _, name := range command.Names() {
-			fmt.Fprintln(c.App.Writer, name)
+		if os.Getenv("_CLI_ZSH_AUTOCOMPLETE_HACK") == "1" {
+			for _, name := range command.Names() {
+				fmt.Fprintf(c.App.Writer, "%s:%s\n", name, command.Usage)
+			}
+		} else {
+			for _, name := range command.Names() {
+				fmt.Fprintf(c.App.Writer, "%s\n", name)
+			}
 		}
 	}
 }
@@ -230,10 +240,8 @@ func printHelpCustom(out io.Writer, templ string, data interface{}, customFunc m
 	funcMap := template.FuncMap{
 		"join": strings.Join,
 	}
-	if customFunc != nil {
-		for key, value := range customFunc {
-			funcMap[key] = value
-		}
+	for key, value := range customFunc {
+		funcMap[key] = value
 	}
 
 	w := tabwriter.NewWriter(out, 1, 8, 2, ' ', 0)

--- a/vendor/github.com/urfave/cli/sort.go
+++ b/vendor/github.com/urfave/cli/sort.go
@@ -1,0 +1,29 @@
+package cli
+
+import "unicode"
+
+// lexicographicLess compares strings alphabetically considering case.
+func lexicographicLess(i, j string) bool {
+	iRunes := []rune(i)
+	jRunes := []rune(j)
+
+	lenShared := len(iRunes)
+	if lenShared > len(jRunes) {
+		lenShared = len(jRunes)
+	}
+
+	for index := 0; index < lenShared; index++ {
+		ir := iRunes[index]
+		jr := jRunes[index]
+
+		if lir, ljr := unicode.ToLower(ir), unicode.ToLower(jr); lir != ljr {
+			return lir < ljr
+		}
+
+		if ir != jr {
+			return ir < jr
+		}
+	}
+
+	return i < j
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c
 github.com/howeyc/gopass
-# github.com/urfave/cli v1.20.0
+# github.com/urfave/cli v1.21.0
 github.com/urfave/cli
 # golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85
 golang.org/x/crypto/ssh/terminal


### PR DESCRIPTION
This change adds additional flags to request-cert command that allows
to specify the input private key file and the output file for generated
certificate request.

Similarly, the sign command will allow to specify input certificate
request file and output file for signed certificate.