### PR TITLE
Automatically inject version from tag in CI

### DIFF
--- a/build
+++ b/build
@@ -4,7 +4,11 @@
 
 ORG_PATH="github.com/square"
 REPO_PATH="${ORG_PATH}/certstrap"
-BUILD_TAG="${TRAVIS_TAG:-$(git describe --all | sed -e's/.*\///g')}"
+BUILD_TAG="${TRAVIS_TAG:-dev-$(git rev-parse HEAD | head -c 8)}"
+
+if [[ $BUILD_TAG == v* ]]; then
+  BUILD_TAG=$(echo $BUILD_TAG | cut -c 2-)
+fi
 
 export GOPATH=${PWD}/gopath
 
@@ -14,6 +18,6 @@ ln -s ${PWD} $GOPATH/src/${REPO_PATH}
 
 eval $(go env)
 
-GOARCH=amd64 GOOS=linux go build -o bin/certstrap-${BUILD_TAG}-linux-amd64 ${REPO_PATH}
-GOARCH=amd64 GOOS=darwin go build -o bin/certstrap-${BUILD_TAG}-darwin-amd64 ${REPO_PATH}
-GOARCH=amd64 GOOS=windows go build -o bin/certstrap-${BUILD_TAG}-windows-amd64 ${REPO_PATH}
+GOARCH=amd64 GOOS=linux go build -ldflags "-X main.release=$BUILD_TAG" -o bin/certstrap-${BUILD_TAG}-linux-amd64 ${REPO_PATH}
+GOARCH=amd64 GOOS=darwin go build -ldflags "-X main.release=$BUILD_TAG" -o bin/certstrap-${BUILD_TAG}-darwin-amd64 ${REPO_PATH}
+GOARCH=amd64 GOOS=windows go build -ldflags "-X main.release=$BUILD_TAG" -o bin/certstrap-${BUILD_TAG}-windows-amd64 ${REPO_PATH}

--- a/certstrap.go
+++ b/certstrap.go
@@ -25,10 +25,13 @@ import (
 	"github.com/urfave/cli"
 )
 
+// release is overriden by the build script using -X argument that is passed to the Go linker.
+var release = "(version not set)"
+
 func main() {
 	app := cli.NewApp()
 	app.Name = "certstrap"
-	app.Version = "1.1.1"
+	app.Version = release
 	app.Usage = "A simple certificate manager written in Go, to bootstrap your own certificate authority and public key infrastructure."
 	app.Flags = []cli.Flag{
 		cli.StringFlag{

--- a/test
+++ b/test
@@ -8,7 +8,9 @@ if [ -z "$PKG" ]; then
     PKG="cmd depot pkix tests"
 fi
 
-export BUILD_TAG="${TRAVIS_TAG:-$(git describe --all | sed -e's/.*\///g')}"
+# tests package relies on BUILD_TAG to be exported
+# BUILD_TAG is set by build script
+export BUILD_TAG
 
 # Unit tests
 echo


### PR DESCRIPTION
This means, if there's a tag, say, v1.2.0, certstrap binaries will be
injected at build time with 1.2.0. At the same time, when running the
build script locally, the binaries will be injected with
1.99.99-dev.GIT_SHA.