### PR TITLE
Add option for creating code-signing certificates.

### DIFF
--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -18,6 +18,7 @@
 package cmd
 
 import (
+	"crypto/x509"
 	"fmt"
 	"os"
 	"strings"
@@ -66,6 +67,10 @@ func NewSignCommand() cli.Command {
 			cli.BoolFlag{
 				Name:  "intermediate",
 				Usage: "Whether generated certificate should be a intermediate",
+			},
+			cli.BoolFlag{
+				Name:  "codsigning",
+				Usage: "Whether generated certificate should include the codeSigning extended key usage extension",
 			},
 		},
 		Action: newSignAction,
@@ -141,6 +146,12 @@ func newSignAction(c *cli.Context) {
 	if c.Bool("intermediate") {
 		fmt.Fprintln(os.Stderr, "Building intermediate")
 		crtOut, err = pkix.CreateIntermediateCertificateAuthority(crt, key, csr, expiresTime)
+	} else if c.Bool("codesigning") {
+		fmt.Fprintln(os.Stderr, "Including codeSigning extended key usage")
+		extKeyUsage := []x509.ExtKeyUsage{
+			x509.ExtKeyUsageCodeSigning,
+		}
+		crtOut, err = pkix.CreateCertificateHostWithExtUsage(crt, key, csr, expiresTime, extKeyUsage)
 	} else {
 		crtOut, err = pkix.CreateCertificateHost(crt, key, csr, expiresTime)
 	}

--- a/pkix/cert_host.go
+++ b/pkix/cert_host.go
@@ -28,6 +28,12 @@ import (
 // CreateCertificateHost creates certificate for host.
 // The arguments include CA certificate, CA key, certificate request.
 func CreateCertificateHost(crtAuth *Certificate, keyAuth *Key, csr *CertificateSigningRequest, proposedExpiry time.Time) (*Certificate, error) {
+	return CreateCertificateHostWithExtUsage(crtAuth, keyAuth, csr, proposedExpiry, nil)
+}
+
+// CreateCertificateHostWithExtUsage creates certificate for host with optional key usage extensions.
+// The arguments include CA certificate, CA key, certificate request, and any key usage extensions.
+func CreateCertificateHostWithExtUsage(crtAuth *Certificate, keyAuth *Key, csr *CertificateSigningRequest, proposedExpiry time.Time, extKeyUsage []x509.ExtKeyUsage) (*Certificate, error) {
 	// Build CA based on RFC5280
 	hostTemplate := x509.Certificate{
 		// **SHOULD** be filled in a unique number
@@ -59,6 +65,10 @@ func CreateCertificateHost(crtAuth *Certificate, keyAuth *Key, csr *CertificateS
 
 		PermittedDNSDomainsCritical: false,
 		PermittedDNSDomains:         nil,
+	}
+
+	if extKeyUsage != nil {
+		hostTemplate.ExtKeyUsage = append(hostTemplate.ExtKeyUsage, extKeyUsage...)
 	}
 
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)


### PR DESCRIPTION
This commit adds support for signing certificates with the codeSigning extended key usage extension. Tried to make this as non-invasive as possible by adding a new function to create host certificates api with an optional array of `[]x509.ExtKeyUsage`. This should allow adding support for other extended key usages in the future. For now, just added a simple boolean flag to the sign command with turns this on.