### PR TITLE
Add option to create CA restricted to some domains

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -85,6 +85,10 @@ func NewInitCommand() cli.Command {
 				Name:  "stdout",
 				Usage: "Print certificate to stdout in addition to saving file",
 			},
+			cli.StringSliceFlag{
+				Name:  "permit-domain",
+				Usage: "Create a CA restricted to subdomains of this domain (can be specified multiple times)",
+			},
 		},
 		Action: initAction,
 	}
@@ -150,7 +154,7 @@ func initAction(c *cli.Context) {
 		}
 	}
 
-	crt, err := pkix.CreateCertificateAuthority(key, c.String("organizational-unit"), expiresTime, c.String("organization"), c.String("country"), c.String("province"), c.String("locality"), c.String("common-name"))
+	crt, err := pkix.CreateCertificateAuthority(key, c.String("organizational-unit"), expiresTime, c.String("organization"), c.String("country"), c.String("province"), c.String("locality"), c.String("common-name"), c.StringSlice("permit-domain"))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Create certificate error:", err)
 		os.Exit(1)

--- a/cmd/revoke_test.go
+++ b/cmd/revoke_test.go
@@ -73,7 +73,7 @@ func setupCA(t *testing.T, dt depot.Depot) {
 	}
 
 	// create certificate authority
-	caCert, err := pkix.CreateCertificateAuthority(key, caName, time.Now().Add(1*time.Minute), "", "", "", "", caName)
+	caCert, err := pkix.CreateCertificateAuthority(key, caName, time.Now().Add(1*time.Minute), "", "", "", "", caName, nil)
 	if err != nil {
 		t.Fatalf("could not create authority cert: %v", err)
 	}

--- a/pkix/cert_auth.go
+++ b/pkix/cert_auth.go
@@ -26,7 +26,7 @@ import (
 
 // CreateCertificateAuthority creates Certificate Authority using existing key.
 // CertificateAuthorityInfo returned is the extra infomation required by Certificate Authority.
-func CreateCertificateAuthority(key *Key, organizationalUnit string, expiry time.Time, organization string, country string, province string, locality string, commonName string) (*Certificate, error) {
+func CreateCertificateAuthority(key *Key, organizationalUnit string, expiry time.Time, organization string, country string, province string, locality string, commonName string, permitDomains []string) (*Certificate, error) {
 	authTemplate := newAuthTemplate()
 
 	subjectKeyID, err := GenerateSubjectKeyID(key.Public)
@@ -52,6 +52,11 @@ func CreateCertificateAuthority(key *Key, organizationalUnit string, expiry time
 	}
 	if len(commonName) > 0 {
 		authTemplate.Subject.CommonName = commonName
+	}
+
+	if len(permitDomains) > 0 {
+		authTemplate.PermittedDNSDomainsCritical = true
+		authTemplate.PermittedDNSDomains = permitDomains
 	}
 
 	crtBytes, err := x509.CreateCertificate(rand.Reader, &authTemplate, &authTemplate, key.Public, key.Private)

--- a/pkix/cert_auth_test.go
+++ b/pkix/cert_auth_test.go
@@ -28,7 +28,7 @@ func TestCreateCertificateAuthority(t *testing.T) {
 		t.Fatal("Failed creating rsa key:", err)
 	}
 
-	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name")
+	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name", []string{".example.com"})
 	if err != nil {
 		t.Fatal("Failed creating certificate authority:", err)
 	}
@@ -51,5 +51,17 @@ func TestCreateCertificateAuthority(t *testing.T) {
 
 	if !time.Now().Before(rawCrt.NotAfter) {
 		t.Fatal("Failed to be before NotAfter")
+	}
+
+	if crt.crt.PermittedDNSDomainsCritical != true {
+		t.Fatal("Permitted DNS Domains is not set to critical")
+	}
+
+	if len(crt.crt.PermittedDNSDomains) != 1 {
+		t.Fatal("More than one entry found in list of permitted DNS domains")
+	}
+
+	if crt.crt.PermittedDNSDomains[0] != ".example.com" {
+		t.Fatalf("Wrong permitted DNS domain, want %q, got %q", ".example.com", crt.crt.PermittedDNSDomains[0])
 	}
 }

--- a/pkix/crl_test.go
+++ b/pkix/crl_test.go
@@ -49,7 +49,7 @@ func TestCreateCertificateRevocationList(t *testing.T) {
 		t.Fatal("Failed creating rsa key:", err)
 	}
 
-	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name")
+	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name", nil)
 	if err != nil {
 		t.Fatal("Failed creating certificate authority:", err)
 	}


### PR DESCRIPTION
As discussed in #92 this PR adds the option to create a CA restricted to subdomains of some domains. Sample usage:

```
$ ./certstrap init --cn myca --permit-domain .example.com --permit-domain .otherdomain.com
```

This is a first version, please let me know what you think! Ideas for future improvement: We could print an error if a certificate is to be signed which is not valid with the restrictions.

IP network restrictions work in a very similar way.

Closes #92