### PR TITLE
Fix docker build after removal of vendored deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,20 @@
 # To run certstrap from the image (for example):
 #     docker run --rm squareup/certstrap --version
 
-FROM golang:1.11.2-alpine as build
+FROM golang:1.13-alpine as build
 
 MAINTAINER Cedric Staub "cs@squareup.com"
 
+WORKDIR /app
+
+COPY go.mod .
+COPY go.sum .
+
+# Download dependencies
+RUN go mod download
+
 # Copy source
-COPY . /go/src/github.com/square/certstrap
+COPY . .
 
 # Build
 RUN go build -o /usr/bin/certstrap github.com/square/certstrap


### PR DESCRIPTION
I believe the docker build broke after merging #93. This change should fix #105