### PR TITLE
Add support for setting pathlen on CA certificates

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -89,6 +89,11 @@ func NewInitCommand() cli.Command {
 				Name:  "permit-domain",
 				Usage: "Create a CA restricted to subdomains of this domain (can be specified multiple times)",
 			},
+			cli.IntFlag{
+				Name:  "path-length",
+				Value: 0,
+				Usage: "Maximum number of non-self-issued intermediate certificates that may follow this CA certificate in a valid certification path",
+			},
 		},
 		Action: initAction,
 	}
@@ -159,7 +164,7 @@ func initAction(c *cli.Context) {
 		}
 	}
 
-	crt, err := pkix.CreateCertificateAuthority(key, c.String("organizational-unit"), expiresTime, c.String("organization"), c.String("country"), c.String("province"), c.String("locality"), c.String("common-name"), c.StringSlice("permit-domain"))
+	crt, err := pkix.CreateCertificateAuthority(key, c.String("organizational-unit"), expiresTime, c.String("organization"), c.String("country"), c.String("province"), c.String("locality"), c.String("common-name"), c.StringSlice("permit-domain"), c.Int("path-length"))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Create certificate error:", err)
 		os.Exit(1)

--- a/cmd/revoke_test.go
+++ b/cmd/revoke_test.go
@@ -75,7 +75,7 @@ func setupCA(t *testing.T, dt depot.Depot) {
 	}
 
 	// create certificate authority
-	caCert, err := pkix.CreateCertificateAuthority(key, caName, time.Now().Add(1*time.Minute), "", "", "", "", caName, nil)
+	caCert, err := pkix.CreateCertificateAuthority(key, caName, time.Now().Add(1*time.Minute), "", "", "", "", caName, nil, 0)
 	if err != nil {
 		t.Fatalf("could not create authority cert: %v", err)
 	}

--- a/pkix/cert_auth.go
+++ b/pkix/cert_auth.go
@@ -26,7 +26,7 @@ import (
 
 // CreateCertificateAuthority creates Certificate Authority using existing key.
 // CertificateAuthorityInfo returned is the extra infomation required by Certificate Authority.
-func CreateCertificateAuthority(key *Key, organizationalUnit string, expiry time.Time, organization string, country string, province string, locality string, commonName string, permitDomains []string) (*Certificate, error) {
+func CreateCertificateAuthority(key *Key, organizationalUnit string, expiry time.Time, organization string, country string, province string, locality string, commonName string, permitDomains []string, pathlen int) (*Certificate, error) {
 	authTemplate := newAuthTemplate()
 
 	subjectKeyID, err := GenerateSubjectKeyID(key.Public)
@@ -57,6 +57,11 @@ func CreateCertificateAuthority(key *Key, organizationalUnit string, expiry time
 	if len(permitDomains) > 0 {
 		authTemplate.PermittedDNSDomainsCritical = true
 		authTemplate.PermittedDNSDomains = permitDomains
+	}
+
+	if pathlen > 0 {
+		authTemplate.MaxPathLen = pathlen
+		authTemplate.MaxPathLenZero = false
 	}
 
 	crtBytes, err := x509.CreateCertificate(rand.Reader, &authTemplate, &authTemplate, key.Public, key.Private)

--- a/pkix/cert_auth_test.go
+++ b/pkix/cert_auth_test.go
@@ -28,7 +28,7 @@ func TestCreateCertificateAuthority(t *testing.T) {
 		t.Fatal("Failed creating rsa key:", err)
 	}
 
-	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name", []string{".example.com"})
+	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name", []string{".example.com"}, 0)
 	if err != nil {
 		t.Fatal("Failed creating certificate authority:", err)
 	}

--- a/pkix/crl_test.go
+++ b/pkix/crl_test.go
@@ -49,7 +49,7 @@ func TestCreateCertificateRevocationList(t *testing.T) {
 		t.Fatal("Failed creating rsa key:", err)
 	}
 
-	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name", nil)
+	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name", nil, 0)
 	if err != nil {
 		t.Fatal("Failed creating certificate authority:", err)
 	}


### PR DESCRIPTION
By default when certstrap initializes a CA certificate it sets the
`pathlen` X509v3 basic constraint to zero (0). This is correct if the CA
will not be used in a certificate chain which includes intermediate
certificates.

Add a parameter to `certstrap init` to allow a user to override the
`pathlen` constraint if they know that their CA will be used with
intermediate certificates. By default the value is set to zero, leaving
the behaviour the same as before this change if the parameter isn't
overridden.

c.f. https://tools.ietf.org/html/rfc5280#section-4.2.1.9

Example usage:

```
$ certstrap init -cn foo.example.com
[...]
$ openssl x509 -noout -text -in out/foo.example.com.crt
[...]
            X509v3 Basic Constraints: critical
                CA:TRUE, pathlen:0
[...]
```

```
$ certstrap init -cn bar.example.com --path-length 1
[...]
$ openssl x509 -noout -text -in out/bar.example.com.crt
[...]
            X509v3 Basic Constraints: critical
                CA:TRUE, pathlen:1
[...]
```

Fixes: https://github.com/square/certstrap/issues/78