### PR TITLE
Fix NotBefore calculation on new certificates

### DIFF
--- a/pkix/cert_auth.go
+++ b/pkix/cert_auth.go
@@ -122,7 +122,7 @@ func newAuthTemplate() x509.Certificate {
 	return x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		// NotBefore is set to be 10min earlier to fix gap on time difference in cluster
-		NotBefore: time.Now().Add(-600).UTC(),
+		NotBefore: time.Now().Add(-10*time.Minute).UTC(),
 		NotAfter:  time.Time{},
 		// Used for certificate signing only
 		KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign,

--- a/pkix/cert_host.go
+++ b/pkix/cert_host.go
@@ -35,7 +35,7 @@ func CreateCertificateHost(crtAuth *Certificate, keyAuth *Key, csr *CertificateS
 		// **SHOULD** be filled in host info
 		Subject: pkix.Name{},
 		// NotBefore is set to be 10min earlier to fix gap on time difference in cluster
-		NotBefore: time.Now().Add(-600).UTC(),
+		NotBefore: time.Now().Add(-10*time.Minute).UTC(),
 		// 10-year lease
 		NotAfter: time.Time{},
 		// Used for certificate signing only


### PR DESCRIPTION
Adding/subtracting from time.Time with a plain integer is making
adjustments by the nanosecond whereas the intention was to create new
certificates that have a validity period starting 10 minutes in the past.