### PR TITLE
add support for multiple organizational units in certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Created out/Alice.csr
 
 certstrap requires either `-common-name` or `-domain` flag to be set in order to generate a certificate signing request.  The CN for the certificate will be found from these fields.
 
-If your server has mutiple ip addresses or domains, use comma seperated ip/domain/uri list. eg: `./certstrap request-cert -ip $ip1,$ip2 -domain $domain1,$domain2 -uri $uri1,$uri2`
+If your server has mutiple ip addresses, domains or organizational units, use comma seperated ip/domain/uri/ou list. eg: `./certstrap request-cert -ip $ip1,$ip2 -domain $domain1,$domain2 -uri $uri1,$uri2 -ou $org1,$org2`
 
 If you do not wish to generate a new keypair, you can use a pre-existing private
 PEM key with the `-key` flag

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -59,7 +59,7 @@ func NewInitCommand() cli.Command {
 			},
 			cli.StringFlag{
 				Name:  "organizational-unit, ou",
-				Usage: "Sets the Organizational Unit (OU) field of the certificate",
+				Usage: "Sets the Organizational Unit (OU) values of the certificate",
 			},
 			cli.StringFlag{
 				Name:  "country, c",

--- a/cmd/request_cert.go
+++ b/cmd/request_cert.go
@@ -63,7 +63,7 @@ func NewCertRequestCommand() cli.Command {
 			},
 			cli.StringFlag{
 				Name:  "organizational-unit, ou",
-				Usage: "Sets the Organizational Unit (OU) field of the certificate",
+				Usage: "Sets the Organizational Unit (OU) values of the certificate",
 			},
 			cli.StringFlag{
 				Name:  "province, st",
@@ -182,7 +182,13 @@ func newCertAction(c *cli.Context) {
 		}
 	}
 
-	csr, err := pkix.CreateCertificateSigningRequest(key, c.String("organizational-unit"), ips, domains, uris, c.String("organization"), c.String("country"), c.String("province"), c.String("locality"), name)
+	// split multiple organizational-unit (if any)
+	organizationalUnits := strings.Split(c.String("organizational-unit"), ",")
+	if c.String("organizational-unit") == "" {
+		organizationalUnits = nil
+	}
+
+	csr, err := pkix.CreateCertificateSigningRequest(key, organizationalUnits, ips, domains, uris, c.String("organization"), c.String("country"), c.String("province"), c.String("locality"), name)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Create certificate request error:", err)
 		os.Exit(1)

--- a/pkix/csr.go
+++ b/pkix/csr.go
@@ -78,11 +78,11 @@ func ParseAndValidateURIs(uriList string) (res []*url.URL, err error) {
 }
 
 // CreateCertificateSigningRequest sets up a request to create a csr file with the given parameters
-func CreateCertificateSigningRequest(key *Key, organizationalUnit string, ipList []net.IP, domainList []string, uriList []*url.URL, organization string, country string, province string, locality string, commonName string) (*CertificateSigningRequest, error) {
+func CreateCertificateSigningRequest(key *Key, organizationalUnits []string, ipList []net.IP, domainList []string, uriList []*url.URL, organization string, country string, province string, locality string, commonName string) (*CertificateSigningRequest, error) {
 	csrPkixName := pkix.Name{CommonName: commonName}
 
-	if len(organizationalUnit) > 0 {
-		csrPkixName.OrganizationalUnit = []string{organizationalUnit}
+	if len(organizationalUnits) > 0 {
+		csrPkixName.OrganizationalUnit = organizationalUnits
 	}
 	if len(organization) > 0 {
 		csrPkixName.Organization = []string{organization}

--- a/tests/organization_unit_test.go
+++ b/tests/organization_unit_test.go
@@ -1,0 +1,56 @@
+//go:build integration
+// +build integration
+
+/*-
+ * Copyright 2015 Square Inc.
+ * Copyright 2014 CoreOS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tests
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestOrganizationalUnit(t *testing.T) {
+	os.RemoveAll(depotDir)
+	defer os.RemoveAll(depotDir)
+
+	// test with single organizational-unit
+	stdout, stderr, err := run(binPath, "request-cert", "--passphrase", passphrase, "--common-name", "CA", "--ou", "ORG-1")
+	if stderr != "" || err != nil {
+		t.Fatalf("Received unexpected error: %v, %v", stderr, err)
+	}
+	if strings.Count(stdout, "Created") != 2 {
+		t.Fatalf("Received incorrect create: %v", stdout)
+	}
+
+	os.RemoveAll(depotDir)
+	defer os.RemoveAll(depotDir)
+
+	// test with multiple  organizational-units
+	stdout, stderr, err = run(binPath, "request-cert", "--passphrase", passphrase, "--common-name", "CA", "--ou", "ORG-1,ORG-2")
+	if stderr != "" || err != nil {
+		t.Fatalf("Received unexpected error: %v, %v", stderr, err)
+	}
+	if strings.Count(stdout, "Created") != 2 {
+		t.Fatalf("Received incorrect create: %v", stdout)
+	}
+
+	os.RemoveAll(depotDir)
+	defer os.RemoveAll(depotDir)
+}


### PR DESCRIPTION
**Background**

We wanted to create a x509 certificate with multiple organizational units (ou). However, the current implementation accepts only a string and do not allow multiple organisations. 

`./bin/certstrap-dev-17687043-darwin-amd64 request-cert --domain "abc.com" -ou "org1,org2"
`

will produce

Certificate Request:
    Data:
        Version: 0 (0x0)
        Subject:
            commonName                = abc.com
            **organizationalUnitName    = org1,org2**
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
                Public-Key: (2048 bit)
                Modulus:
                    00:9d:19:c9:78:d6:48:e6:23:26:fc:b4:86:03:1f:
                    fc:dd:9d:b2:32:78:01:a5:a1:75:ee:ef:05:3d:ac:
                    99:21:7b:f3:3b:69:a6:fc:7a:7e:8c:e2:2a:da:28:
                    38:f2:1a:91:1a:ab:39:4c:53:8b:5e:60:2c:49:cc:
                    0d:90:42:82:69:99:ae:a6:87:0f:4f:92:dd:ed:4a:
.....
....

**USAGE**

`./bin/certstrap-dev-17687043-darwin-amd64 request-cert --domain "abc.com" -ou "org1,org2"`

will produce

Certificate Request:
    Data:
        Version: 0 (0x0)
        Subject:
            commonName                = CertAuth
            **organizationalUnitName    = ORG-2 + organizationalUnitName    = ORG-1**
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
                Public-Key: (2048 bit)
                Modulus:
                    00:c8:9b:80:1f:9e:d4:71:26:ad:35:0c:a3:25:6e:
                    02:73:7f:c6:fd:23:97:9d:8d:dd:39:cb:19:4f:34:
                    9c:8d:31:03:00:50:11:02:24:c9:22:fe:62:c0:b0:
                    f0:25:5c:18:5b:4f:29:1b:73:29:9a:b7:ef:fa:d0:
                    35:7d:9a:3e:35:f3:31:9c:e0:29:1d:6a:f1:96:98:
                    29:6f:c1:bc:2d:9d:a6:8c:2c:00:a7:cb:ae:30:76:
                   .....
......

Note. In openssl, the generations of multiple organizational-units works fine.
