### PR TITLE
Use CA key instead of the subject key in the revocation test

### DIFF
--- a/cmd/revoke_test.go
+++ b/cmd/revoke_test.go
@@ -113,7 +113,12 @@ func setupCN(t *testing.T, dt depot.Depot) {
 		t.Fatalf("could not get cert: %v", err)
 	}
 
-	cnCert, err := pkix.CreateCertificateHost(caCert, key, csr, time.Now().Add(1*time.Hour))
+	caKey, err := depot.GetPrivateKey(dt, caName)
+	if err != nil {
+		t.Fatalf("could not get CA key: %v", err)
+	}
+
+	cnCert, err := pkix.CreateCertificateHost(caCert, caKey, csr, time.Now().Add(1*time.Hour))
 	if err != nil {
 		t.Fatalf("could not create cert host: %v", err)
 	}


### PR DESCRIPTION
Go 1.17 added checks that a CA's public key matches the signing key used. The test was using the wrong key.

Closes #121 