### PR TITLE
Exclude the deprecated PEM functions from CI lints

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,3 +40,5 @@ jobs:
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v2
+      with:
+        - only-new-issues: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,5 +40,8 @@ jobs:
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v2
+
       with:
-        args: --exclude '(Decrypt|Encrypt)PEMBlock'
+        # Exclude deprecated PEM functions from the linter until
+        # https://github.com/square/certstrap/issues/124 is resolved
+        args: --exclude '(De|En)cryptPEMBlock'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,4 +41,4 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
-        only-new-issues: true
+        args: --exclude '(Decrypt|Encrypt)PEMBlock'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,4 +41,4 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
-        - only-new-issues: true
+        only-new-issues: true


### PR DESCRIPTION
The lints from #124 will always cause CI to fail. Ignore them for now.