### PR TITLE
Allow stricter permissions but not looser; Change default permissions to 0400; Correct and improve `unprotected key file' message.

### DIFF
--- a/depot/depot.go
+++ b/depot/depot.go
@@ -113,8 +113,8 @@ func (d *FileDepot) check(tag *Tag) error {
 	if err != nil {
 		return err
 	}
-	if ^fi.Mode()&tag.perm != 0 {
-		return errors.New("permission denied")
+	if fi.Mode()&^tag.perm != 0 {
+		return errors.New("unprotected key file `" + tag.name + "': file permissions too open")
 	}
 	return nil
 }

--- a/depot/depot.go
+++ b/depot/depot.go
@@ -101,7 +101,7 @@ func (d *FileDepot) Put(tag *Tag, data []byte) error {
 // Check returns whether the file at the tag location exists and has the correct permissions
 func (d *FileDepot) Check(tag *Tag) bool {
 	name := d.path(tag.name)
-	if fi, err := os.Stat(name); err == nil && ^fi.Mode()&tag.perm == 0 {
+	if fi, err := os.Stat(name); err == nil && fi.Mode()&^tag.perm == 0 {
 		return true
 	}
 	return false

--- a/depot/depot_test.go
+++ b/depot/depot_test.go
@@ -31,7 +31,7 @@ const (
 var (
 	tag       = &Tag{"host.pem", 0600}
 	tag2      = &Tag{"host2.pem", 0600}
-	wrongTag  = &Tag{"host.pem", 0666}
+	wrongTag  = &Tag{"host.pem", 0400}
 	wrongTag2 = &Tag{"host.pem2", 0600}
 )
 
@@ -101,7 +101,7 @@ func TestDepotCheckFailure(t *testing.T) {
 	}
 
 	if d.Check(wrongTag) {
-		t.Fatal("Expect not to checking out file with insufficient permission")
+		t.Fatal("Expect not to checking out unprotected file")
 	}
 
 	if d.Check(wrongTag2) {
@@ -122,7 +122,7 @@ func TestDepotGetFailure(t *testing.T) {
 	}
 
 	if _, err := d.Get(wrongTag); err == nil {
-		t.Fatal("Expect not to checking out file with insufficient permission")
+		t.Fatal("Expect not to checking out unprotected file")
 	}
 
 	if _, err := d.Get(wrongTag2); err == nil {

--- a/depot/pkix.go
+++ b/depot/pkix.go
@@ -31,8 +31,8 @@ const (
 )
 
 const (
-	BranchPerm = 0440
-	LeafPerm   = 0444
+	BranchPerm = 0400
+	LeafPerm   = 0400
 )
 
 // CrtTag returns a tag corresponding to a certificate


### PR DESCRIPTION
This pull request:
* Allows stricter permissions but not looser
* Changes default permissions to 0400
* Changes `permission denied` => ``unprotected key file `FILENAME': file permissions too open``
* Fixes: https://github.com/square/certstrap/issues/51, https://github.com/square/certstrap/issues/136, https://github.com/square/certstrap/issues/137