### PR TITLE
updated go version to 1.16 in response to permission denied issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,4 @@ require (
 	go.step.sm/crypto v0.15.2
 )
 
-go 1.13
+go 1.16


### PR DESCRIPTION
Recently, there have been certstrap issues with "permission denied":

https://github.com/square/certstrap/issues/144
https://github.com/square/certstrap/issues/149

It appears that the reason for this is that the go version is too old.
