### PR TITLE
created separate perms for windows so that windows users will no longer experience permission denied issues

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -71,19 +71,3 @@ jobs:
 
     - name: Run integration tests
       run: ./integration_test
-
-  lint-windows:
-    name: Lint Windows
-    runs-on: windows-latest
-    steps:
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
-    - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v2
-
-      with:
-        # Exclude deprecated PEM functions from the linter until
-        # https://github.com/square/certstrap/issues/124 is resolved
-        args: --exclude '(De|En)cryptPEMBlock'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,3 +45,45 @@ jobs:
         # Exclude deprecated PEM functions from the linter until
         # https://github.com/square/certstrap/issues/124 is resolved
         args: --exclude '(De|En)cryptPEMBlock'
+  
+  build-windows:
+    name: Build Windows
+    runs-on: windows-latest
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.17
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: go mod download
+
+    - name: Run tests
+      run: go test -v ./...
+
+    - name: Build binaries
+      run: ./build
+
+    - name: Run integration tests
+      run: ./integration_test
+
+  lint-windows:
+    name: Lint Windows
+    runs-on: windows-latest
+    steps:
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v2
+
+      with:
+        # Exclude deprecated PEM functions from the linter until
+        # https://github.com/square/certstrap/issues/124 is resolved
+        args: --exclude '(De|En)cryptPEMBlock'

--- a/depot/depot_test.go
+++ b/depot/depot_test.go
@@ -29,11 +29,6 @@ const (
 	dir  = ".certstrap-test"
 )
 
-var (
-	tag  = &Tag{"host.pem", 0600}
-	tag2 = &Tag{"host2.pem", 0600}
-)
-
 func getDepot(t *testing.T) *FileDepot {
 	os.RemoveAll(dir)
 

--- a/depot/perms.go
+++ b/depot/perms.go
@@ -1,0 +1,9 @@
+//go:build !windows
+// +build !windows
+
+package depot
+
+const (
+	BranchPerm = 0440
+	LeafPerm   = 0444
+)

--- a/depot/perms_windows.go
+++ b/depot/perms_windows.go
@@ -1,0 +1,10 @@
+package depot
+
+const (
+	// 0440 is not supported on Windows (which only allows for all-read or all-write permissions)
+	// Because our permissions checking requires permissions to meet a minimum criteria,
+	// requiring 0440 for the leaf perm (key files) in windows will cause the permissions check to fail,
+	// resulting permission denied errors for Windows users.
+	BranchPerm = 0444
+	LeafPerm   = 0444
+)

--- a/depot/pkix.go
+++ b/depot/pkix.go
@@ -30,11 +30,6 @@ const (
 	crlSuffix     = ".crl"
 )
 
-const (
-	BranchPerm = 0440
-	LeafPerm   = 0444
-)
-
 // CrtTag returns a tag corresponding to a certificate
 func CrtTag(prefix string) *Tag {
 	return &Tag{prefix + crtSuffix, LeafPerm}

--- a/depot/test_tags.go
+++ b/depot/test_tags.go
@@ -1,0 +1,9 @@
+//go:build !windows
+// +build !windows
+
+package depot
+
+var (
+	tag  = &Tag{"host.pem", 0600}
+	tag2 = &Tag{"host2.pem", 0600}
+)

--- a/depot/test_tags_windows.go
+++ b/depot/test_tags_windows.go
@@ -1,0 +1,7 @@
+package depot
+
+// windows does not allow 0600 permissions so we need to set test tags to be 0666
+var (
+	tag  = &Tag{"host.pem", 0666}
+	tag2 = &Tag{"host2.pem", 0666}
+)


### PR DESCRIPTION
Context: https://square.slack.com/archives/C03C3457C01/p1652248777115799?thread_ts=1650924230.904889&cid=C03C3457C01

TL;DR windows does not allow 440 permissions (which were being set for key files in certstap). In reality, the key files were being given 444 permissions.

However, this was previously allowed because file permissions checking in certstrap was flawed - it was allowing files with looser permissions than expected to be used. This was fixed in https://github.com/square/certstrap/pull/141. However, the side effect of this fix was that certstrap broke in windows due to 444 (the actual key file permissions) being looser than 440. This PR fixes this by setting special leaf perms to be 444 for windows only.