### PR TITLE
Expand on permissions error message.

### DIFF
--- a/depot/depot.go
+++ b/depot/depot.go
@@ -115,7 +115,7 @@ func (d *FileDepot) check(tag *Tag) error {
 		return err
 	}
 	if !checkPermissions(tag.perm, fi.Mode()) {
-		return errors.New("permission denied")
+		return fmt.Errof("permissions too lax for %v: required no more than %v, found %v", name, tag.perm, fi.Mode())
 	}
 	return nil
 }

--- a/depot/depot.go
+++ b/depot/depot.go
@@ -19,6 +19,7 @@ package depot
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"io/ioutil"
 	"os"
@@ -115,7 +116,7 @@ func (d *FileDepot) check(tag *Tag) error {
 		return err
 	}
 	if !checkPermissions(tag.perm, fi.Mode()) {
-		return fmt.Errof("permissions too lax for %v: required no more than %v, found %v", name, tag.perm, fi.Mode())
+		return fmt.Errorf("permissions too lax for %v: required no more than %v, found %v", name, tag.perm, fi.Mode())
 	}
 	return nil
 }


### PR DESCRIPTION
If permissions are not as expected by certstrap it will give a very terse "permission denied" message that gives no indication of what the error is or how to address it.  This small PR expands the error message to explain with which file the permissions problem lies, and why the problem arose.  This allows users to be able to address the issue.