### PR TITLE
WIP: allow revocation with passphrase-protected CAs

### DIFF
--- a/cmd/revoke.go
+++ b/cmd/revoke.go
@@ -77,7 +77,7 @@ func (c *revokeCommand) run(ctx *cli.Context) {
 		RevocationTime: time.Now(),
 	})
 
-	err = c.saveRevokedCertificates(caCert, revoked)
+	err = c.saveRevokedCertificates(ctx, caCert, revoked)
 	c.checkErr(err)
 }
 
@@ -111,16 +111,25 @@ func (c *revokeCommand) revokedCertificates() ([]x509pkix.RevokedCertificate, er
 	return certList.TBSCertList.RevokedCertificates, nil
 }
 
-func (c *revokeCommand) saveRevokedCertificates(cert *x509.Certificate, list []x509pkix.RevokedCertificate) error {
-	priv, err := depot.GetPrivateKey(d, c.ca)
+func (c *revokeCommand) saveRevokedCertificates(ctx *cli.Context, cert *x509.Certificate, list []x509pkix.RevokedCertificate) error {
+	privateKey, err := depot.GetPrivateKey(d, c.ca)
 	if err != nil {
-		return fmt.Errorf("could not get %q private key: %v", c.ca, err)
+		pass, err := getPassPhrase(ctx, "CA key")
+		if err != nil {
+			return fmt.Errorf("error retreiving passphrase when saving revoked certificates: %v", err)
+		}
+		privateKey, err = depot.GetEncryptedPrivateKey(d, c.ca, pass)
+		if err != nil {
+			return fmt.Errorf("get CA key error when saving revoked certificates: %v", err)
+		}
 	}
 
-	crlBytes, err := cert.CreateCRL(rand.Reader, priv.Private, list, time.Now(), time.Now().Add(2*8760*time.Hour))
+	crlBytes, err := cert.CreateCRL(rand.Reader, privateKey.Private, list, time.Now(), time.Now().Add(2*8760*time.Hour))
 	if err != nil {
 		return fmt.Errorf("could not create CRL: %v", err)
 	}
+	fmt.Println(depot.CrlTag(c.ca))
+
 	if err := d.Delete(depot.CrlTag(c.ca)); err != nil {
 		return fmt.Errorf("could not delete CRL: %v", err)
 	}


### PR DESCRIPTION
This addresses https://github.com/square/certstrap/issues/110

Currently a WIP because I attempted to add unit testing for when a passphrase is set for the CA. However, I'm not currently sure how to provide the password when calling revoke.run (since `askPassPhrase` directly calls `gopass.GetPasswdPrompt`).