### PR TITLE
Allow password-protected CAs to call revoke command

### DIFF
--- a/cmd/revoke.go
+++ b/cmd/revoke.go
@@ -27,6 +27,10 @@ func NewRevokeCommand() cli.Command {
 		Description: "Add certificate to the CA's CRL.",
 		Flags: []cli.Flag{
 			cli.StringFlag{
+				Name:  "passphrase",
+				Usage: "Passphrase to decrypt private-key PEM block of CA",
+			},
+			cli.StringFlag{
 				Name:  "CN",
 				Usage: "Common Name (CN) of certificate to revoke",
 			},

--- a/cmd/revoke.go
+++ b/cmd/revoke.go
@@ -77,7 +77,7 @@ func (c *revokeCommand) run(ctx *cli.Context) {
 		RevocationTime: time.Now(),
 	})
 
-	err = c.saveRevokedCertificates(caCert, revoked)
+	err = c.saveRevokedCertificates(ctx, caCert, revoked)
 	c.checkErr(err)
 }
 
@@ -111,13 +111,20 @@ func (c *revokeCommand) revokedCertificates() ([]x509pkix.RevokedCertificate, er
 	return certList.TBSCertList.RevokedCertificates, nil
 }
 
-func (c *revokeCommand) saveRevokedCertificates(cert *x509.Certificate, list []x509pkix.RevokedCertificate) error {
-	priv, err := depot.GetPrivateKey(d, c.ca)
+func (c *revokeCommand) saveRevokedCertificates(ctx *cli.Context, cert *x509.Certificate, list []x509pkix.RevokedCertificate) error {
+	privateKey, err := depot.GetPrivateKey(d, c.ca)
 	if err != nil {
-		return fmt.Errorf("could not get %q private key: %v", c.ca, err)
+		pass, err := getPassPhrase(ctx, "CA key")
+		if err != nil {
+			return fmt.Errorf("error retreiving passphrase when saving revoked certificates: %v", err)
+		}
+		privateKey, err = depot.GetEncryptedPrivateKey(d, c.ca, pass)
+		if err != nil {
+			return fmt.Errorf("get CA key error when saving revoked certificates: %v", err)
+		}
 	}
 
-	crlBytes, err := cert.CreateCRL(rand.Reader, priv.Private, list, time.Now(), time.Now().Add(2*8760*time.Hour))
+	crlBytes, err := cert.CreateCRL(rand.Reader, privateKey.Private, list, time.Now(), time.Now().Add(2*8760*time.Hour))
 	if err != nil {
 		return fmt.Errorf("could not create CRL: %v", err)
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -64,6 +64,8 @@ func createPassPhrase() ([]byte, error) {
 }
 
 func askPassPhrase(name string) ([]byte, error) {
+	fmt.Println("calling GetPasswdPrompt")
+
 	pass, err := gopass.GetPasswdPrompt(fmt.Sprintf("Enter passphrase for %v (empty for no passphrase): ", name), false, os.Stdin, os.Stdout)
 	if err != nil {
 		return nil, err
@@ -73,6 +75,7 @@ func askPassPhrase(name string) ([]byte, error) {
 
 func getPassPhrase(c *cli.Context, name string) ([]byte, error) {
 	if c.IsSet("passphrase") {
+		fmt.Println("getPassPhrase is set")
 		return []byte(c.String("passphrase")), nil
 	}
 	return askPassPhrase(name)

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -64,8 +64,6 @@ func createPassPhrase() ([]byte, error) {
 }
 
 func askPassPhrase(name string) ([]byte, error) {
-	fmt.Println("calling GetPasswdPrompt")
-
 	pass, err := gopass.GetPasswdPrompt(fmt.Sprintf("Enter passphrase for %v (empty for no passphrase): ", name), false, os.Stdin, os.Stdout)
 	if err != nil {
 		return nil, err
@@ -75,7 +73,6 @@ func askPassPhrase(name string) ([]byte, error) {
 
 func getPassPhrase(c *cli.Context, name string) ([]byte, error) {
 	if c.IsSet("passphrase") {
-		fmt.Println("getPassPhrase is set")
 		return []byte(c.String("passphrase")), nil
 	}
 	return askPassPhrase(name)

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -112,6 +112,14 @@ func TestWorkflow(t *testing.T) {
 			if cert.PublicKeyAlgorithm != tc.expected {
 				t.Fatalf("Public key algorithm = %d, want %d", cert.PublicKeyAlgorithm, tc.expected)
 			}
+
+			stdout, stderr, err = run(binPath, "revoke", "--CN", hostname, "--CA", "CA")
+			if stderr != "" || err != nil {
+				t.Fatalf("Received unexpected error: %v, %v", stderr, err)
+			}
+			if strings.Count(stdout, hostname) != 0 {
+				t.Fatalf("Received incorrect create: %v", stdout)
+			}
 		})
 	}
 }

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -113,7 +113,7 @@ func TestWorkflow(t *testing.T) {
 				t.Fatalf("Public key algorithm = %d, want %d", cert.PublicKeyAlgorithm, tc.expected)
 			}
 
-			stdout, stderr, err = run(binPath, "revoke", "--CN", hostname, "--CA", "CA")
+			stdout, stderr, err = run(binPath, "revoke", "--passphrase", passphrase, "--CN", hostname, "--CA", "CA")
 			if stderr != "" || err != nil {
 				t.Fatalf("Received unexpected error: %v, %v", stderr, err)
 			}


### PR DESCRIPTION
This addresses https://github.com/square/certstrap/issues/110

We test this in workflow_test.go, which is an integration test. We check to make sure that calling revoke does not result in any errors.

I also added password as a flag to the revoke command (mainly for integration testing purposes - this is a common pattern in workflow_test.go).

Manual Testing: I ran go build for certstrap so that I can run certstrap with the updates in this PR - the successful case is with the Alice cert, and the failure case (i.e. we fail to supply the passphrase when revoking) with Bob):

```
~/Development/certstrap isemaya/certstrap-fix-revoke-key-for-passphrase-protected-ca ./certstrap init --common-name "CertAuth"
Enter passphrase (empty for no passphrase): 
Enter same passphrase again: 
Created out/CertAuth.key (encrypted by passphrase)
Created out/CertAuth.crt
Created out/CertAuth.crl
~/Development/certstrap isemaya/certstrap-fix-revoke-key-for-passphrase-protected-ca ls
CODEOWNERS      Dockerfile      NOTICE          certstrap       cmd             go.mod          out             tests
CONTRIBUTING.md LICENSE         README.md       certstrap.go    depot           go.sum          pkix
~/Development/certstrap isemaya/certstrap-fix-revoke-key-for-passphrase-protected-ca ./certstrap request-cert --common-name Alice
Enter passphrase (empty for no passphrase): 
Enter same passphrase again: 
Created out/Alice.key
Created out/Alice.csr
~/Development/certstrap isemaya/certstrap-fix-revoke-key-for-passphrase-protected-ca ./certstrap sign Alice --CA CertAuth
Enter passphrase for CA key (empty for no passphrase): 
Created out/Alice.crt from out/Alice.csr signed by out/CertAuth.key
~/Development/certstrap isemaya/certstrap-fix-revoke-key-for-passphrase-protected-ca ./certstrap revoke --CN Alice --CA CertAuth
Enter passphrase for CA key (empty for no passphrase): 
~/Development/certstrap isemaya/certstrap-fix-revoke-key-for-passphrase-protected-ca ./certstrap sign Alice --CA CertAuth
Certificate "Alice" already exists!
~/Development/certstrap isemaya/certstrap-fix-revoke-key-for-passphrase-protected-ca ./certstrap sign Robert --CA CertAuth
Get certificate request error: stat /Users/isemaya/Development/certstrap/out/Robert.csr: no such file or directory
~/Development/certstrap isemaya/certstrap-fix-revoke-key-for-passphrase-protected-ca ./certstrap request-cert --common-name Bob
Enter passphrase (empty for no passphrase): 
Enter same passphrase again: 
Created out/Bob.key
Created out/Bob.csr
~/Development/certstrap isemaya/certstrap-fix-revoke-key-for-passphrase-protected-ca ./certstrap sign Bob --CA CertAuth
Enter passphrase for CA key (empty for no passphrase): 
Created out/Bob.crt from out/Bob.csr signed by out/CertAuth.key
~/Development/certstrap isemaya/certstrap-fix-revoke-key-for-passphrase-protected-ca ./certstrap revoke --CN Bob --CA CertAuth
Enter passphrase for CA key (empty for no passphrase): 
get CA key error when saving revoked certificates: x509: decryption password incorrect
```